### PR TITLE
Update d2-ui-components and pass api to orgUnitSelector

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "d2": "^31.1.1",
         "d2-api": "0.0.2-beta.15",
         "d2-manifest": "^1.0.0",
-        "d2-ui-components": "1.0.3-beta.5",
+        "d2-ui-components": "1.0.3-beta.6",
         "enzyme": "^3.7.0",
         "enzyme-adapter-react-16": "^1.6.0",
         "enzyme-to-json": "^3.3.4",

--- a/public/app-config.json
+++ b/public/app-config.json
@@ -1,7 +1,7 @@
 {
     "appKey": "project-monitoring-app",
     "appearance": {
-        "showShareButton": true
+        "showShareButton": false
     },
     "feedback": {
         "token": ["03242fc6b0c5a48582", "2e6b8d3e8337b5a0b95fe2"],

--- a/src/components/org-units/UserOrgUnits.tsx
+++ b/src/components/org-units/UserOrgUnits.tsx
@@ -49,11 +49,11 @@ const UserOrgUnits: React.FC<UserOrgUnitsProps> = props => {
     const [rootIds, setRootIds] = useState<string[]>([]);
     const snackbar = useSnackbar();
     const classes = useStyles();
-    const { d2, api, config } = useAppContext();
-    const user = new User(config);
+    const { api, config } = useAppContext();
     const { onChange, selected, selectableLevels, withElevation = true, height } = props;
 
     useEffect(() => {
+        const user = new User(config);
         const rootIds = user.getOrgUnits().map(ou => ou.id);
         if (_(rootIds).isEmpty()) {
             snackbar.error(
@@ -62,7 +62,7 @@ const UserOrgUnits: React.FC<UserOrgUnitsProps> = props => {
         } else {
             setRootIds(rootIds);
         }
-    }, [d2]);
+    }, [config]);
 
     async function onChangeOu(orgUnitPaths: string[]) {
         const lastSelectedPath = _.last(orgUnitPaths);
@@ -74,7 +74,7 @@ const UserOrgUnits: React.FC<UserOrgUnitsProps> = props => {
         <div className={classes.wrapper}>
             {rootIds.length > 0 ? (
                 <OrgUnitsSelector
-                    d2={d2}
+                    api={api}
                     onChange={onChangeOu}
                     selected={selected ? [selected.path] : []}
                     selectableLevels={selectableLevels}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4108,10 +4108,10 @@ d2-manifest@^1.0.0:
     minimist "^1.1.0"
     readline-sync "^1.4.1"
 
-d2-ui-components@1.0.3-beta.5:
-  version "1.0.3-beta.5"
-  resolved "https://registry.npmjs.org/d2-ui-components/-/d2-ui-components-1.0.3-beta.5.tgz#ba309faac2e02afb43fb913d0f178a836c92980c"
-  integrity sha512-czkiHIw6NxNQY95QE+NRBO3xbu2IZ6elszJryMZwrVhvRwPVRjh570hl/iOJw0lPfyiVKsNqrAo1qOJAM2Tg4Q==
+d2-ui-components@1.0.3-beta.6:
+  version "1.0.3-beta.6"
+  resolved "https://registry.npmjs.org/d2-ui-components/-/d2-ui-components-1.0.3-beta.6.tgz#6aff44f1e5a8eb490c24df8a57f2a90b60b99222"
+  integrity sha512-GOGbauqT5qQOMEvb84snsxtvR2Gu8y7qXLwGcZXXwFcBUvfbWi60T7EfQfoD67Hl4xxkUhHQhbk1KoWWdmqU1A==
   dependencies:
     "@date-io/core" "^1.3.6"
     "@date-io/moment" "^1.0.2"


### PR DESCRIPTION
### :pushpin: References

* **d2-ui-components**: Requires https://github.com/EyeSeeTea/d2-ui-components/pull/117. Already as beta.