### PR TITLE
Fix indicators multi sectorial with paired elements in both sectors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,7 +23,6 @@ module.exports = {
         "@typescript-eslint/ban-ts-ignore": "off",
         "@typescript-eslint/no-empty-function": "off",
         "react-hooks/exhaustive-deps": "off",
-        "array-callback-return": "off",
     },
     plugins: ["cypress"],
     env: { "cypress/globals": true },

--- a/cypress/integration/08.project-indicators.spec.js
+++ b/cypress/integration/08.project-indicators.spec.js
@@ -12,6 +12,8 @@ describe("Projects - Indicators", () => {
     it("selects indicators with dependencies", () => {
         cy.contains("Sectors").click();
         selectInMultiSelector("sectors", "Protection");
+        selectInMultiSelector("sectors", "Food");
+        selectInMultiSelector("sectors", "Nutrition");
         cy.contains("Next").click();
 
         new IndicatorsPage(cy)
@@ -59,7 +61,17 @@ describe("Projects - Indicators", () => {
             .selectSector("Protection")
             // Select an indicator which has a paired sub indicator, its global should be also selected
             .select("B100500")
-            .assertExactSelected(["B100500", "P100701", "P100700"]);
+            .assertExactSelected(["B100500", "P100701", "P100700"])
+
+            .selectSector("Nutrition")
+            // Select a cross-sectorial indicator which has paired sub indicators in other sectors (Food)
+            .select("B050102")
+            .assertExactSelected(["B050102", "P050202", "P040100"])
+
+            .selectSector("Food")
+            // Now check the same cross-sectorial indicator in the other sector
+            .select("B050102")
+            .assertExactSelected(["B050102", "P050202", "B050100", "P050200"]);
 
         // MER Indicators
         cy.contains("Selection of MER Indicators").click();

--- a/src/components/data-entry/DataSetStateButton.tsx
+++ b/src/components/data-entry/DataSetStateButton.tsx
@@ -54,7 +54,7 @@ const DataSetStateButton: React.FunctionComponent<DataSetStateButtonProps> = pro
                 </Button>
             )}
 
-            {dataSetInfo.isDataSetReopened && (
+            {dataSetInfo.isPeriodOpen && dataSetInfo.isDataSetReopened && (
                 <Button
                     disabled={isActive}
                     className={classes.button}

--- a/src/models/Project.ts
+++ b/src/models/Project.ts
@@ -447,6 +447,7 @@ class Project {
                 } else {
                     const msg = `Indicator ${indicatorCode} not found for data element ${de.code}`;
                     console.error(msg);
+                    return null;
                 }
             })
             .compact()

--- a/src/models/ProjectDb.ts
+++ b/src/models/ProjectDb.ts
@@ -245,7 +245,7 @@ export default class ProjectDb {
     saveMERData(orgUnitId: Id): D2ApiResponse<void> {
         const dataStore = getDataStore(this.project.api);
         const dataElementsForMER = this.project.dataElementsMER.get({ onlySelected: true });
-        const ids = _.uniq(dataElementsForMER.map(de => de.id));
+        const ids = _.sortBy(_.uniq(dataElementsForMER.map(de => de.id)));
         const value: ProjectInfo = { merDataElementIds: ids };
         return dataStore.save(getProjectStorageKey({ id: orgUnitId }), value);
     }

--- a/src/models/__tests__/ProjectDb.spec.ts
+++ b/src/models/__tests__/ProjectDb.spec.ts
@@ -109,7 +109,7 @@ const orgUnitsMetadata = {
 };
 
 const expectedDataStoreMer = {
-    merDataElementIds: ["yMqK9DKbA3X", "WS8XV4WWPE7"],
+    merDataElementIds: ["WS8XV4WWPE7", "yMqK9DKbA3X"],
 };
 
 const expectedOrgUnitPut = {

--- a/src/models/dataElementsSet.ts
+++ b/src/models/dataElementsSet.ts
@@ -135,10 +135,13 @@ export default class DataElementsSet {
 
             if (!indicatorType) {
                 console.error(`DataElement ${deCode} has no indicator type`);
+                return null;
             } else if (!peopleOrBenefit) {
                 console.error(`DataElement ${deCode} has no indicator type people/benefit`);
+                return null;
             } else if (!mainSector) {
                 console.error(`DataElement ${deCode} has no main sector`);
+                return null;
             } else {
                 const dataElement: DataElementBase = {
                     id: d2DataElement.id,
@@ -272,6 +275,8 @@ export default class DataElementsSet {
                 if (de.indicatorType === "sub") {
                     const key = ["global", de.series].join(".");
                     return _(allDataElementsByKey).get(key, null);
+                } else {
+                    return null;
                 }
             })
         );


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #202

### :memo: Implementation

- We were identifying main/paired indicators in a single loop for all indicators. Instead, this processing is now performed independently for each sector, so all relations are kept.
- Added cypress spec with the example provided by the client.
- I re-enabled the array-callback-return eslint rule, as it's really helpful on finding bugs (when inadvertently using `()=> {}` instead of `() => ()`, without a return)