### PR TITLE
Update to versioned d2-api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
     # Login to docker
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
     # Start docker service
-    - d2-docker start eyeseetea/dhis2-data:2.32-samaritans-test -d --port=8080
+    - d2-docker start eyeseetea/dhis2-data:2.32-samaritans -d --port=8080
 install:
     - yarn install --frozen-lockfile
     - yarn cy:verify

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "axios": "^0.19.2",
         "classnames": "^2.2.6",
         "d2": "^31.8.1",
-        "d2-api": "0.2.2-beta.2",
+        "d2-api": "1.0.0-beta.2",
         "d2-manifest": "^1.0.0",
         "d2-ui-components": "1.3.0",
         "exceljs": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "axios": "^0.19.2",
         "classnames": "^2.2.6",
         "d2": "^31.8.1",
-        "d2-api": "0.2.0",
+        "d2-api": "0.2.2-beta.2",
         "d2-manifest": "^1.0.0",
         "d2-ui-components": "1.3.0",
         "exceljs": "^3.5.0",

--- a/src/components/app/App.tsx
+++ b/src/components/app/App.tsx
@@ -12,7 +12,7 @@ import i18n from "@dhis2/d2-i18n";
 //@ts-ignore
 import { init } from "d2";
 import { SnackbarProvider } from "d2-ui-components";
-import { D2ApiDefault } from "d2-api";
+import { D2Api } from "../../types/d2-api";
 
 import "./App.css";
 import { muiTheme } from "./themes/dhis2.theme";
@@ -97,7 +97,7 @@ const App = () => {
                 credentials: "same-origin",
             }).then(res => res.json());
             const d2 = await init({ baseUrl: baseUrl + "/api" });
-            const api = new D2ApiDefault({ baseUrl });
+            const api = new D2Api({ baseUrl });
             const config = await getConfig(api);
 
             configI18n(data.userSettings);

--- a/src/components/delete-dialog/DeleteDialog.tsx
+++ b/src/components/delete-dialog/DeleteDialog.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Id } from "d2-api";
+import { Id } from "../../types/d2-api";
 import { withSnackbarOnError } from "../utils/errors";
 import { useSnackbar, ConfirmationDialog } from "d2-ui-components";
 import Project from "../../models/Project";

--- a/src/components/org-units/UserOrgUnits.tsx
+++ b/src/components/org-units/UserOrgUnits.tsx
@@ -6,7 +6,7 @@ import { useAppContext } from "../../contexts/api-context";
 import User from "../../models/user";
 import i18n from "../../locales";
 import { getIdFromOrgUnit } from "../../utils/dhis2";
-import { D2Api } from "d2-api";
+import { D2Api } from "../../types/d2-api";
 import { makeStyles } from "@material-ui/styles";
 
 type Path = string;

--- a/src/components/steps/data-elements/DataElementsTable.tsx
+++ b/src/components/steps/data-elements/DataElementsTable.tsx
@@ -5,7 +5,7 @@ import _ from "lodash";
 import DataElementsFilters, { Filter } from "./DataElementsFilters";
 import i18n from "../../../locales";
 import DataElementsSet, { SelectionInfo, DataElement } from "../../../models/dataElementsSet";
-import { Id } from "d2-api";
+import { Id } from "../../../types/d2-api";
 
 export interface DataElementsTableProps {
     dataElementsSet: DataElementsSet;
@@ -122,7 +122,7 @@ function withPaired<Field extends keyof DataElement>(
     mapper?: (val: DataElement[Field]) => string
 ) {
     const mapper_ = mapper || _.identity;
-    const render = function(dataElement: DataElement, _value: ReactNode) {
+    const render = (dataElement: DataElement, _value: ReactNode) => {
         const values = [dataElement, ...dataElement.pairedDataElements].map(de =>
             mapper_(de[field])
         );

--- a/src/components/steps/utils/common.tsx
+++ b/src/components/steps/utils/common.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import _ from "lodash";
 import { CSSProperties } from "@material-ui/core/styles/withStyles";
-import { Ref } from "d2-api";
+import { Ref } from "../../../types/d2-api";
 
 export function getValuesFromSelection<Option extends Ref>(
     options: Option[],

--- a/src/contexts/api-context.ts
+++ b/src/contexts/api-context.ts
@@ -1,6 +1,6 @@
 import { Config } from "../models/Config";
 import React, { useContext } from "react";
-import { D2Api } from "d2-api";
+import { D2Api } from "../types/d2-api";
 import User from "../models/user";
 
 export interface AppContext {

--- a/src/dev/get-download.ts
+++ b/src/dev/get-download.ts
@@ -1,11 +1,11 @@
 import fs from "fs";
 import { getConfig } from "./../models/Config";
 import Project from "../models/Project";
-import { D2ApiDefault } from "d2-api";
+import { D2Api } from "../types/d2-api";
 
 async function main() {
     const baseUrl = "http://admin:EsT@Staging1234!@localhost:8032";
-    const api = new D2ApiDefault({ baseUrl });
+    const api = new D2Api({ baseUrl });
     const config = await getConfig(api);
     const project = await Project.get(api, config, "WUDKKsUKqVH");
     const { filename, buffer } = await project.download();

--- a/src/models/Config.ts
+++ b/src/models/Config.ts
@@ -1,5 +1,5 @@
 import _ from "lodash";
-import { D2ApiDefault, D2Api, Id, Ref, MetadataPick } from "d2-api";
+import { D2Api, Id, Ref, MetadataPick } from "../types/d2-api";
 import fs from "fs";
 import path from "path";
 import DataElementsSet, { DataElementBase } from "./dataElementsSet";
@@ -297,7 +297,7 @@ export async function getConfig(api: D2Api): Promise<Config> {
 /* Runnable script to generate __tests__/config.json */
 
 async function getFromApp(baseUrl: string) {
-    const api = new D2ApiDefault({ baseUrl });
+    const api = new D2Api({ baseUrl });
     const allConfig = await getConfig(api);
     // Protect names for funders, locations and data elements.
     const config: Config = {

--- a/src/models/MerReport.ts
+++ b/src/models/MerReport.ts
@@ -1,10 +1,9 @@
 import { GetItemType } from "./../types/utils";
 import moment, { Moment } from "moment";
 import _ from "lodash";
-import { D2Api, Id, Ref, D2OrganisationUnit } from "d2-api";
+import { Id, Ref, D2Api, D2OrganisationUnit, DataStore } from "../types/d2-api";
 import { Config } from "./Config";
 import { getDataStore } from "../utils/dhis2";
-import DataStore from "d2-api/api/dataStore";
 import { runPromises } from "../utils/promises";
 import { getProjectFromOrgUnit, getOrgUnitDatesFromProject } from "./Project";
 import { toISOString, getMonthsRange } from "../utils/date";

--- a/src/models/Project.ts
+++ b/src/models/Project.ts
@@ -1,7 +1,8 @@
 import { Config, Sector as SectorC, Funder as FunderC, Location as LocationC } from "./Config";
 import moment, { Moment } from "moment";
 import _ from "lodash";
-import { D2Api, SelectedPick, Id, Ref, D2OrganisationUnit, D2IndicatorSchema } from "d2-api";
+import { D2Api, SelectedPick, Id, Ref } from "../types/d2-api";
+import { D2OrganisationUnit, D2IndicatorSchema } from "../types/d2-api";
 import { generateUid } from "d2/uid";
 import { TableSorting } from "d2-ui-components";
 

--- a/src/models/ProjectAnalytics.ts
+++ b/src/models/ProjectAnalytics.ts
@@ -1,5 +1,5 @@
 import _ from "lodash";
-import { Ref } from "d2-api";
+import { Ref } from "../types/d2-api";
 import Project from "./Project";
 import { DataElement } from "./dataElementsSet";
 import { getIds } from "../utils/dhis2";

--- a/src/models/ProjectDashboard.ts
+++ b/src/models/ProjectDashboard.ts
@@ -1,6 +1,6 @@
-import { PartialPersistedModel, PartialModel } from "d2-api/api/common";
+import { PartialPersistedModel, PartialModel } from "../types/d2-api";
 import _ from "lodash";
-import { D2Dashboard, D2ReportTable, Ref, D2Chart, D2DashboardItem, Id } from "d2-api";
+import { D2Dashboard, D2ReportTable, Ref, D2Chart, D2DashboardItem, Id } from "../types/d2-api";
 import Project from "./Project";
 import i18n from "../locales";
 import { getUid } from "../utils/dhis2";

--- a/src/models/ProjectDataSet.ts
+++ b/src/models/ProjectDataSet.ts
@@ -1,6 +1,6 @@
 import moment, { Moment } from "moment";
 import _ from "lodash";
-import { Id, D2Api, D2DataInputPeriod } from "d2-api";
+import { Id, D2Api, D2DataInputPeriod } from "../types/d2-api";
 import { Config } from "./Config";
 import Project, { OrganisationUnit, DataSet, DataSetType } from "./Project";
 import ProjectDb, { DataSetOpenAttributes } from "./ProjectDb";

--- a/src/models/ProjectDb.ts
+++ b/src/models/ProjectDb.ts
@@ -1,8 +1,9 @@
 import _ from "lodash";
 import moment from "moment";
-import { D2DataSet, D2OrganisationUnit, D2ApiResponse, MetadataPayload, Id, D2Api } from "d2-api";
-import { SelectedPick, D2OrganisationUnitSchema } from "d2-api";
-import { PartialModel, Ref, PartialPersistedModel, MetadataResponse } from "d2-api";
+import { MetadataPayload, Id, D2Api } from "../types/d2-api";
+import { D2DataSet, D2OrganisationUnit, D2ApiResponse } from "../types/d2-api";
+import { SelectedPick, D2OrganisationUnitSchema } from "../types/d2-api";
+import { PartialModel, Ref, PartialPersistedModel, MetadataResponse } from "../types/d2-api";
 import Project, { getOrgUnitDatesFromProject, getDatesFromOrgUnit, DataSetType } from "./Project";
 import { getMonthsRange, toISOString } from "../utils/date";
 import "../utils/lodash-mixins";
@@ -149,7 +150,8 @@ export default class ProjectDb {
         const dbDataSet = _(dataSets).get(0, null);
 
         if (dbDataSet) {
-            const res = await this.api.models.dataSets.put({ ...dbDataSet, ...attrs }).getData();
+            const dataSetAttrs = { ...dbDataSet, ...attrs, id: dbDataSet.id };
+            const res = await this.api.models.dataSets.put(dataSetAttrs).getData();
 
             if (res.status !== "OK") throw new Error("Error saving data set");
         }

--- a/src/models/ProjectDelete.ts
+++ b/src/models/ProjectDelete.ts
@@ -1,6 +1,6 @@
 import _ from "lodash";
 import { Config } from "./Config";
-import { D2Api, Id, Ref, MetadataPayload } from "d2-api";
+import { D2Api, Id, Ref, MetadataPayload } from "../types/d2-api";
 import { getIds, getRefs, postMetadataRequests, getDataStore } from "../utils/dhis2";
 import i18n from "../locales";
 import { getDashboardId } from "./ProjectDb";

--- a/src/models/ProjectsList.ts
+++ b/src/models/ProjectsList.ts
@@ -1,6 +1,6 @@
 import _ from "lodash";
 import { TableSorting, TablePagination } from "d2-ui-components";
-import { D2Api, D2OrganisationUnitSchema, SelectedPick, Id } from "d2-api";
+import { D2Api, D2OrganisationUnitSchema, SelectedPick, Id } from "../types/d2-api";
 import { Config } from "./Config";
 import moment from "moment";
 import { Sector, getOrgUnitDatesFromProject, getProjectFromOrgUnit } from "./Project";

--- a/src/models/__tests__/MerReport.spec.ts
+++ b/src/models/__tests__/MerReport.spec.ts
@@ -1,4 +1,4 @@
-import { getMockApi } from "d2-api";
+import { getMockApi } from "../../types/d2-api";
 import MerReport from "../MerReport";
 import config from "./config";
 import moment from "moment";

--- a/src/models/__tests__/MerReportSpreadsheet.spec.ts
+++ b/src/models/__tests__/MerReportSpreadsheet.spec.ts
@@ -1,4 +1,4 @@
-import { getMockApi } from "d2-api";
+import { getMockApi } from "../../types/d2-api";
 import MerReport from "../MerReport";
 import config from "./config";
 import moment from "moment";

--- a/src/models/__tests__/Project.spec.ts
+++ b/src/models/__tests__/Project.spec.ts
@@ -1,4 +1,4 @@
-import { getMockApi } from "d2-api";
+import { getMockApi } from "../../types/d2-api";
 import _ from "lodash";
 import { ValidationKey } from "./../Project";
 import Project from "../Project";

--- a/src/models/__tests__/ProjectDb.spec.ts
+++ b/src/models/__tests__/ProjectDb.spec.ts
@@ -1,4 +1,4 @@
-import { getMockApi } from "d2-api";
+import { getMockApi } from "../../types/d2-api";
 import ProjectDb from "../ProjectDb";
 import { getProject } from "./project-data";
 

--- a/src/models/__tests__/ProjectDownload.spec.ts
+++ b/src/models/__tests__/ProjectDownload.spec.ts
@@ -1,6 +1,6 @@
 import ExcelJS, { Workbook } from "exceljs";
 import _ from "lodash";
-import { getMockApi } from "d2-api";
+import { getMockApi } from "../../types/d2-api";
 import Project from "../Project";
 import { getProject } from "./project-data";
 import moment from "moment";

--- a/src/models/__tests__/project-data.ts
+++ b/src/models/__tests__/project-data.ts
@@ -1,5 +1,5 @@
 import { ProjectData } from "./../Project";
-import { D2Api } from "d2-api";
+import { D2Api } from "../../types/d2-api";
 import _ from "lodash";
 import moment from "moment";
 import Project from "../Project";

--- a/src/models/dataElementsSet.ts
+++ b/src/models/dataElementsSet.ts
@@ -1,5 +1,5 @@
 import _ from "lodash";
-import { Id, Ref } from "d2-api";
+import { Id, Ref } from "../types/d2-api";
 
 import { Config, DataElementGroupSet, BaseConfig, Metadata, CurrentUser } from "./Config";
 import { Sector } from "./Config";

--- a/src/models/dev-project.ts
+++ b/src/models/dev-project.ts
@@ -1,5 +1,5 @@
 import md5 from "md5";
-import { D2Api, DataValueSetsPostRequest } from "d2-api";
+import { D2Api, DataValueSetsPostRequest } from "../types/d2-api";
 import _ from "lodash";
 import Project from "./Project";
 import moment from "moment";

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -10,7 +10,7 @@ import { History } from "history";
 import { useAppContext } from "../../contexts/api-context";
 import Project from "../../models/Project";
 import { generateUrl } from "../../router";
-import { D2Api } from "d2-api";
+import { D2Api } from "../../types/d2-api";
 import { Config } from "../../models/Config";
 
 function goTo(history: History, url: string) {

--- a/src/pages/data-approval/DataApproval.tsx
+++ b/src/pages/data-approval/DataApproval.tsx
@@ -6,7 +6,7 @@ import { makeStyles } from "@material-ui/core/styles";
 import { Paper, Button } from "@material-ui/core";
 import Dropdown from "../../components/dropdown/Dropdown";
 import Project, { getPeriodsData, DataSetType, dataSetTypes } from "../../models/Project";
-import { D2Api } from "d2-api";
+import { D2Api } from "../../types/d2-api";
 import { Config } from "../../models/Config";
 
 import { useAppContext } from "../../contexts/api-context";

--- a/src/pages/data-values/DataValues.tsx
+++ b/src/pages/data-values/DataValues.tsx
@@ -9,7 +9,7 @@ import { generateUrl } from "../../router";
 import { LinearProgress } from "@material-ui/core";
 import Project, { DataSet } from "../../models/Project";
 import { useAppContext } from "../../contexts/api-context";
-import { D2Api } from "d2-api";
+import { D2Api } from "../../types/d2-api";
 import { Config } from "../../models/Config";
 import { link } from "../../utils/form";
 

--- a/src/pages/project-wizard/ProjectWizard.tsx
+++ b/src/pages/project-wizard/ProjectWizard.tsx
@@ -6,7 +6,7 @@ import { LinearProgress } from "@material-ui/core";
 import { History, Location } from "history";
 
 import Project, { ValidationKey } from "../../models/Project";
-import { D2Api } from "d2-api";
+import { D2Api } from "../../types/d2-api";
 import { generateUrl } from "../../router";
 import i18n from "../../locales";
 import ExitWizardButton from "../../components/wizard/ExitWizardButton";

--- a/src/pages/projects-list/ProjectsList.tsx
+++ b/src/pages/projects-list/ProjectsList.tsx
@@ -12,7 +12,7 @@ import { formatDateShort, formatDateLong } from "../../utils/date";
 import ActionButton from "../../components/action-button/ActionButton";
 import { GetPropertiesByType } from "../../types/utils";
 import { downloadFile } from "../../utils/download";
-import { D2Api, Id } from "d2-api";
+import { D2Api, Id } from "../../types/d2-api";
 import { Icon, LinearProgress, CircularProgress } from "@material-ui/core";
 import ProjectsListFilters, { Filter } from "./ProjectsListFilters";
 import { ProjectForList, FiltersForList } from "../../models/ProjectsList";

--- a/src/types/d2-api.ts
+++ b/src/types/d2-api.ts
@@ -1,0 +1,5 @@
+import { D2Api } from "d2-api/2.32";
+import { getMockApiFromClass } from "d2-api";
+
+export * from "d2-api/2.32";
+export const getMockApi = getMockApiFromClass(D2Api);

--- a/src/utils/dhis2.ts
+++ b/src/utils/dhis2.ts
@@ -1,7 +1,7 @@
 import _ from "lodash";
 import md5 from "md5";
-import { D2Api, Ref, Id, MetadataPayload } from "d2-api";
-import { PostOptions } from "d2-api/api/metadata";
+
+import { D2Api, Ref, Id, MetadataPayload, PostOptions } from "../types/d2-api";
 import { runPromises } from "./promises";
 
 export function getIds<T extends Ref>(objs: T[]): Id[] {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4668,10 +4668,10 @@ cypress@^4.0.1:
     url "0.11.0"
     yauzl "2.10.0"
 
-d2-api@0.2.2-beta.2:
-  version "0.2.2-beta.2"
-  resolved "https://registry.npmjs.org/d2-api/-/d2-api-0.2.2-beta.2.tgz#0acff6acfc09da4ab9f02432ee8cb58722054f15"
-  integrity sha512-LuCmEHacZpLOqhvS/eBUPdKYXpdrDtlXH0y86zBVo4KLY5yK7uyTbWZ45BJ9hWRYORb7KXUtMqZYyyJXzCBWhg==
+d2-api@1.0.0-beta.2:
+  version "1.0.0-beta.2"
+  resolved "https://registry.npmjs.org/d2-api/-/d2-api-1.0.0-beta.2.tgz#f146ea1abf40c73833fb0eda80cb2d845db7534f"
+  integrity sha512-k306KYuNvE9rFS7vPA54WcjWIsQrfAvyywNWGvM/ZUohXlpi95/ttzFCzWqrlbSFQKPwWZME18XpeSAKotYcsg==
   dependencies:
     "@babel/runtime" "^7.5.4"
     "@dhis2/d2-i18n" "^1.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4668,10 +4668,10 @@ cypress@^4.0.1:
     url "0.11.0"
     yauzl "2.10.0"
 
-d2-api@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/d2-api/-/d2-api-0.2.0.tgz#e9a5a403db8216a910670e43baa53c923a304a10"
-  integrity sha512-A3BxaSPgssoBRDGetpxhBy33ja/9Pg6vKQ/J4WKQxAYR51cgnOTKhu4qtFqagYCx9XEg5DCSUn9osn8aVwrydw==
+d2-api@0.2.2-beta.2:
+  version "0.2.2-beta.2"
+  resolved "https://registry.npmjs.org/d2-api/-/d2-api-0.2.2-beta.2.tgz#0acff6acfc09da4ab9f02432ee8cb58722054f15"
+  integrity sha512-LuCmEHacZpLOqhvS/eBUPdKYXpdrDtlXH0y86zBVo4KLY5yK7uyTbWZ45BJ9hWRYORb7KXUtMqZYyyJXzCBWhg==
   dependencies:
     "@babel/runtime" "^7.5.4"
     "@dhis2/d2-i18n" "^1.0.5"


### PR DESCRIPTION
### :pushpin: References

Apply changes from https://github.com/EyeSeeTea/d2-api/pull/41

### :memo: Implementation

-  Only `src/types/d2-api.ts` imports d2-api for the target version and re-export for the rest of the app to use.