### PR TITLE
Rename app: project monitoring -> data management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,6 @@ cypress/videos/
 
 # Custom
 scripts/
-project-monitoring-app.zip
+data-monitoring-app.zip
 bak/
 src/dev

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,6 @@ cypress/videos/
 
 # Custom
 scripts/
-data-monitoring-app.zip
+data-management-app.zip
 bak/
 src/dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
     - REACT_APP_CYPRESS=true yarn build-webapp
 script:
     - yarn wait-on http-get://localhost:8080
-    - curl -F file=@data-monitoring-app.zip -X POST -u "$CYPRESS_DHIS2_AUTH" "http://localhost:8080/api/apps"
+    - curl -F file=@data-management-app.zip -X POST -u "$CYPRESS_DHIS2_AUTH" "http://localhost:8080/api/apps"
     - CYPRESS_EXTERNAL_API=http://localhost:8080 CYPRESS_ROOT_URL=http://localhost:8080  yarn cy:e2e:run --record --key ae48c13f-96a1-4850-b8b2-d5329b3c4813
     - kill $(jobs -p) || true
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
 script:
     - yarn wait-on http-get://localhost:8080
     - curl -F file=@data-management-app.zip -X POST -u "$CYPRESS_DHIS2_AUTH" "http://localhost:8080/api/apps"
-    - CYPRESS_EXTERNAL_API=http://localhost:8080 CYPRESS_ROOT_URL=http://localhost:8080  yarn cy:e2e:run --record --key ae48c13f-96a1-4850-b8b2-d5329b3c4813
+    - CYPRESS_EXTERNAL_API=http://localhost:8080 CYPRESS_ROOT_URL=http://localhost:8080  yarn cy:e2e:run
     - kill $(jobs -p) || true
 addons:
     apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
     - REACT_APP_CYPRESS=true yarn build-webapp
 script:
     - yarn wait-on http-get://localhost:8080
-    - curl -F file=@project-monitoring-app.zip -X POST -u "$CYPRESS_DHIS2_AUTH" "http://localhost:8080/api/apps"
+    - curl -F file=@data-monitoring-app.zip -X POST -u "$CYPRESS_DHIS2_AUTH" "http://localhost:8080/api/apps"
     - CYPRESS_EXTERNAL_API=http://localhost:8080 CYPRESS_ROOT_URL=http://localhost:8080  yarn cy:e2e:run --record --key ae48c13f-96a1-4850-b8b2-d5329b3c4813
     - kill $(jobs -p) || true
 addons:

--- a/README.md
+++ b/README.md
@@ -94,6 +94,6 @@ $ yarn build-webapp
 
 A project consist of these Dhis2 metadata:
 
--   1 organisation unit (level 2). attributes: `PM_PROJECT_DASHBOARD_ID`
--   2 data sets: actual and target. attributes: `PM_ORGUNIT_PROJECT_ID`
+-   1 organisation unit (level 2). attributes: `DM_PROJECT_DASHBOARD_ID`
+-   2 data sets: actual and target. attributes: `DM_ORGUNIT_PROJECT_ID`
 -   1 dashboard.

--- a/cypress/integration/00.project-create.spec.js
+++ b/cypress/integration/00.project-create.spec.js
@@ -111,7 +111,7 @@ describe("Projects - Create", () => {
 
         cy.waitForStep("Username Access");
         cy.contains("System Admin");
-        cy.contains("Project Monitoring Admin");
+        cy.contains("Data Management Admin");
         cy.contains("Country Admin Bahamas");
         cy.contains("Next").click();
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "data-monitoring-app",
+    "name": "data-management-app",
     "description": "DHIS2 Data Management App",
     "version": "0.4.0",
     "license": "GPL-3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "project-monitoring-app",
-    "description": "DHIS2 Project Monitoring App",
+    "description": "DHIS2 Data Management App",
     "version": "0.4.0",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
@@ -112,8 +112,8 @@
         "wait-on": "^4.0.0"
     },
     "manifest.webapp": {
-        "name": "Project Monitoring App",
-        "description": "DHIS2 Project Monitoring App",
+        "name": "Data Management App",
+        "description": "DHIS2 Data Management App",
         "icons": {
             "48": "icon.png"
         },

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "eject": "react-scripts eject",
         "prettify": "prettier \"{src,config,cypress}/**/*.{js,jsx,json,css,ts,tsx}\" --write",
         "extract-pot": "d2-i18n-extract -p src/ -o i18n/",
-        "localize": "yarn update-po && d2-i18n-generate -n project-monitoring-app -p ./i18n/ -o ./src/locales/",
+        "localize": "yarn update-po && d2-i18n-generate -n data-management-app -p ./i18n/ -o ./src/locales/",
         "update-po": "yarn extract-pot && find i18n -name '*.po' | while read pofile; do msgmerge --backup=off -U $pofile i18n/en.pot; done",
         "manifest": "d2-manifest package.json build/manifest.webapp",
         "cy:verify": "cypress verify",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "project-monitoring-app",
+    "name": "data-monitoring-app",
     "description": "DHIS2 Data Management App",
     "version": "0.4.0",
     "license": "GPL-3.0",

--- a/public/app-config.json
+++ b/public/app-config.json
@@ -1,15 +1,22 @@
 {
-    "appKey": "project-monitoring-app",
+    "appKey": "data-management-app",
     "appearance": {
         "showShareButton": false
     },
     "app": {
-        "notifyEmailOnProjectSave": ["user@server.com"]
+        "notifyEmailOnProjectSave": [
+            "user@server.com"
+        ]
     },
     "feedback": {
-        "token": ["03242fc6b0c5a48582", "2e6b8d3e8337b5a0b95fe2"],
+        "token": [
+            "03242fc6b0c5a48582",
+            "2e6b8d3e8337b5a0b95fe2"
+        ],
         "createIssue": true,
-        "sendToDhis2UserGroups": ["Administrators"],
+        "sendToDhis2UserGroups": [
+            "Administrators"
+        ],
         "issues": {
             "repository": "EyeSeeTea/SP-project-monitoring-app",
             "title": "[User feedback] {title}",

--- a/public/index.html
+++ b/public/index.html
@@ -26,7 +26,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-        <title>Project Monitoring App</title>
+        <title>Data Management App</title>
 
         <script src="//code.jquery.com/jquery-latest.min.js"></script>
         <script src="%PUBLIC_URL%/feedback-tool/feedback.min.js"></script>

--- a/src/components/app/App.tsx
+++ b/src/components/app/App.tsx
@@ -97,7 +97,7 @@ const App: React.FC<AppProps> = props => {
             const appContext = { d2, api, config, currentUser, isDev, isTest, appConfig };
             setAppContext(appContext);
 
-            Object.assign(window, { pm: appContext });
+            Object.assign(window, { dm: appContext });
 
             setShowShareButton(_(appConfig).get("appearance.showShareButton") || false);
             const isFeedbackRole =

--- a/src/components/app/App.tsx
+++ b/src/components/app/App.tsx
@@ -134,7 +134,7 @@ const App: React.FC<AppProps> = props => {
             <MuiThemeProvider theme={muiTheme}>
                 <OldMuiThemeProvider muiTheme={muiThemeLegacy}>
                     <SnackbarProvider>
-                        <HeaderBar appName={"Project Monitoring"} />
+                        <HeaderBar appName={"Data Management"} />
 
                         <div id="app" className="content">
                             <ApiContext.Provider value={appContext}>

--- a/src/models/Config.ts
+++ b/src/models/Config.ts
@@ -48,7 +48,7 @@ const baseConfig = {
     },
     attributes: {
         pairedDataElement: "PM_PAIRED_DE",
-        createdByApp: "PM_CREATED_BY_PROJECT_MONITORING",
+        createdByApp: "PM_CREATED_BY_DATA_MANAGEMENT",
         orgUnitProject: "PM_ORGUNIT_PROJECT_ID",
         projectDashboard: "PM_PROJECT_DASHBOARD_ID",
         countingMethod: "PM_COUNTING_METHOD",

--- a/src/models/Config.ts
+++ b/src/models/Config.ts
@@ -33,10 +33,10 @@ const baseConfig = {
         levelForProjects: 3,
     },
     userRoles: {
-        feedback: ["PM Feedback"],
+        feedback: ["DM Feedback"],
         dataReviewer: ["Data Reviewer"],
         dataViewer: ["Data Viewer"],
-        admin: ["PM Admin"],
+        admin: ["DM Admin"],
         dataEntry: ["Data Entry"],
     },
     dataElementGroupSets: {
@@ -47,12 +47,12 @@ const baseConfig = {
         externals: "EXTERNAL",
     },
     attributes: {
-        pairedDataElement: "PM_PAIRED_DE",
-        createdByApp: "PM_CREATED_BY_DATA_MANAGEMENT",
-        orgUnitProject: "PM_ORGUNIT_PROJECT_ID",
-        projectDashboard: "PM_PROJECT_DASHBOARD_ID",
-        countingMethod: "PM_COUNTING_METHOD",
-        mainSector: "PM_MAIN_SECTOR",
+        pairedDataElement: "DM_PAIRED_DE",
+        createdByApp: "DM_CREATED_BY_DATA_MANAGEMENT",
+        orgUnitProject: "DM_ORGUNIT_PROJECT_ID",
+        projectDashboard: "DM_PROJECT_DASHBOARD_ID",
+        countingMethod: "DM_COUNTING_METHOD",
+        mainSector: "DM_MAIN_SECTOR",
     },
     categories: {
         default: "default",
@@ -96,7 +96,7 @@ const baseConfig = {
         costBenefitPrefix: "COST_BENEFIT_",
     },
     dataApprovalWorkflows: {
-        project: "PM_PROJECT",
+        project: "DM_PROJECT",
     },
     userGroups: {
         systemAdmin: "SYSTEM_ADMIN",

--- a/src/models/Config.ts
+++ b/src/models/Config.ts
@@ -100,7 +100,7 @@ const baseConfig = {
     },
     userGroups: {
         systemAdmin: "SYSTEM_ADMIN",
-        appAdmin: "PROJECT_MONITORING_ADMIN",
+        appAdmin: "DATA_MANAGEMENT_ADMIN",
         countryAdminPrefix: "ADMIN_COUNTRY_",
     },
 };

--- a/src/models/__tests__/Project.spec.ts
+++ b/src/models/__tests__/Project.spec.ts
@@ -79,7 +79,7 @@ describe("Project", () => {
                 },
             }).replyOnce(200, metadataForGet);
 
-            mock.onGet("/dataStore/project-monitoring-app/project-R3rGhxWbAI9").replyOnce(200, {
+            mock.onGet("/dataStore/data-management-app/project-R3rGhxWbAI9").replyOnce(200, {
                 merDataElementIds: ["u24zk6wAgFE"],
             });
 

--- a/src/models/__tests__/ProjectDb.spec.ts
+++ b/src/models/__tests__/ProjectDb.spec.ts
@@ -332,7 +332,7 @@ const expectedMetadataPost = {
             dataElementDecoration: true,
             renderAsTabs: true,
             categoryCombo: {
-                id: "pQjIEZS8Sx7",
+                id: "qAgB0mD1wC6",
             },
             organisationUnits: [
                 {
@@ -358,7 +358,7 @@ const expectedMetadataPost = {
                 },
             ],
             workflow: {
-                id: "SXvbJzbogqj",
+                id: "CCy0oNyvlV1",
             },
             dataInputPeriods: [
                 {
@@ -436,7 +436,7 @@ const expectedMetadataPost = {
                         id: "K6mAC5SiO29",
                     },
                     categoryCombo: {
-                        id: "GKWiemQPU5U",
+                        id: "S0GIshZAqgK",
                     },
                 },
                 {
@@ -447,7 +447,7 @@ const expectedMetadataPost = {
                         id: "ik0ICagvIjm",
                     },
                     categoryCombo: {
-                        id: "GKWiemQPU5U",
+                        id: "S0GIshZAqgK",
                     },
                 },
                 {
@@ -469,7 +469,7 @@ const expectedMetadataPost = {
                         id: "GQyudNlGzkI",
                     },
                     categoryCombo: {
-                        id: "GKWiemQPU5U",
+                        id: "S0GIshZAqgK",
                     },
                 },
             ],
@@ -483,8 +483,8 @@ const expectedMetadataPost = {
                     access: "rwrw----",
                 },
                 {
-                    id: "KAQv2ZlGCLn",
-                    displayName: "Project Monitoring Admin",
+                    id: "mKKNXzeIAJs",
+                    displayName: "Data Management Admin",
                     access: "rwrw----",
                 },
             ],
@@ -496,7 +496,7 @@ const expectedMetadataPost = {
             dataElementDecoration: true,
             renderAsTabs: true,
             categoryCombo: {
-                id: "pQjIEZS8Sx7",
+                id: "qAgB0mD1wC6",
             },
             organisationUnits: [
                 {
@@ -522,7 +522,7 @@ const expectedMetadataPost = {
                 },
             ],
             workflow: {
-                id: "SXvbJzbogqj",
+                id: "CCy0oNyvlV1",
             },
             dataInputPeriods: [
                 {
@@ -600,7 +600,7 @@ const expectedMetadataPost = {
                         id: "K6mAC5SiO29",
                     },
                     categoryCombo: {
-                        id: "GKWiemQPU5U",
+                        id: "S0GIshZAqgK",
                     },
                 },
                 {
@@ -611,7 +611,7 @@ const expectedMetadataPost = {
                         id: "ik0ICagvIjm",
                     },
                     categoryCombo: {
-                        id: "GKWiemQPU5U",
+                        id: "S0GIshZAqgK",
                     },
                 },
                 {
@@ -633,7 +633,7 @@ const expectedMetadataPost = {
                         id: "GQyudNlGzkI",
                     },
                     categoryCombo: {
-                        id: "GKWiemQPU5U",
+                        id: "S0GIshZAqgK",
                     },
                 },
             ],
@@ -647,8 +647,8 @@ const expectedMetadataPost = {
                     access: "rwrw----",
                 },
                 {
-                    id: "KAQv2ZlGCLn",
-                    displayName: "Project Monitoring Admin",
+                    id: "mKKNXzeIAJs",
+                    displayName: "Data Management Admin",
                     access: "rwrw----",
                 },
             ],
@@ -769,8 +769,8 @@ const expectedMetadataPost = {
                     access: "rw------",
                 },
                 {
-                    id: "KAQv2ZlGCLn",
-                    displayName: "Project Monitoring Admin",
+                    id: "mKKNXzeIAJs",
+                    displayName: "Data Management Admin",
                     access: "rw------",
                 },
             ],
@@ -884,8 +884,8 @@ const expectedMetadataPost = {
                     access: "rw------",
                 },
                 {
-                    id: "KAQv2ZlGCLn",
-                    displayName: "Project Monitoring Admin",
+                    id: "mKKNXzeIAJs",
+                    displayName: "Data Management Admin",
                     access: "rw------",
                 },
             ],
@@ -992,20 +992,20 @@ const expectedMetadataPost = {
                 },
                 {
                     code: "NEW_RETURNING",
-                    id: "a0Cy1qwUuZv",
+                    id: "uSMHdwhxFSV",
                     categoryOptions: [
                         {
                             code: "NEW",
-                            id: "S2y8dcmR2kD",
+                            id: "KiK0FMExoqh",
                         },
                         {
                             code: "RETURNING",
-                            id: "CyILz2yY8ey",
+                            id: "a6AJLXQy8vO",
                         },
                     ],
                 },
             ],
-            rowDimensions: ["dx", "GIIHAr9BzzO", "a0Cy1qwUuZv"],
+            rowDimensions: ["dx", "GIIHAr9BzzO", "uSMHdwhxFSV"],
             categoryDimensions: [
                 {
                     category: {
@@ -1035,14 +1035,14 @@ const expectedMetadataPost = {
                 },
                 {
                     category: {
-                        id: "a0Cy1qwUuZv",
+                        id: "uSMHdwhxFSV",
                     },
                     categoryOptions: [
                         {
-                            id: "S2y8dcmR2kD",
+                            id: "KiK0FMExoqh",
                         },
                         {
-                            id: "CyILz2yY8ey",
+                            id: "a6AJLXQy8vO",
                         },
                     ],
                 },
@@ -1057,8 +1057,8 @@ const expectedMetadataPost = {
                     access: "rw------",
                 },
                 {
-                    id: "KAQv2ZlGCLn",
-                    displayName: "Project Monitoring Admin",
+                    id: "mKKNXzeIAJs",
+                    displayName: "Data Management Admin",
                     access: "rw------",
                 },
             ],
@@ -1144,30 +1144,30 @@ const expectedMetadataPost = {
                     id: "ou",
                 },
                 {
-                    id: "a0Cy1qwUuZv",
+                    id: "uSMHdwhxFSV",
                     categoryOptions: [
                         {
                             code: "NEW",
-                            id: "S2y8dcmR2kD",
+                            id: "KiK0FMExoqh",
                             categoryOptionCombos: [
                                 {
-                                    id: "UU2P0YSJM8A",
+                                    id: "aoRpDH3cNkD",
                                 },
                                 {
-                                    id: "bOokLlHM9no",
+                                    id: "kYnK9rhdUYO",
                                 },
                                 {
-                                    id: "kx33GL2khoi",
+                                    id: "KB5Mfe7zpOw",
                                 },
                                 {
-                                    id: "nwv02VfyQuz",
+                                    id: "RZeJX0Tg9Tx",
                                 },
                             ],
                         },
                     ],
                 },
             ],
-            filterDimensions: ["ou", "a0Cy1qwUuZv"],
+            filterDimensions: ["ou", "uSMHdwhxFSV"],
             rows: [
                 {
                     id: "dx",
@@ -1217,11 +1217,11 @@ const expectedMetadataPost = {
                 },
                 {
                     category: {
-                        id: "a0Cy1qwUuZv",
+                        id: "uSMHdwhxFSV",
                     },
                     categoryOptions: [
                         {
-                            id: "S2y8dcmR2kD",
+                            id: "KiK0FMExoqh",
                         },
                     ],
                 },
@@ -1236,8 +1236,8 @@ const expectedMetadataPost = {
                     access: "rw------",
                 },
                 {
-                    id: "KAQv2ZlGCLn",
-                    displayName: "Project Monitoring Admin",
+                    id: "mKKNXzeIAJs",
+                    displayName: "Data Management Admin",
                     access: "rw------",
                 },
             ],
@@ -1321,8 +1321,8 @@ const expectedMetadataPost = {
                     access: "rw------",
                 },
                 {
-                    id: "KAQv2ZlGCLn",
-                    displayName: "Project Monitoring Admin",
+                    id: "mKKNXzeIAJs",
+                    displayName: "Data Management Admin",
                     access: "rw------",
                 },
             ],
@@ -1416,8 +1416,8 @@ const expectedMetadataPost = {
                     access: "rw------",
                 },
                 {
-                    id: "KAQv2ZlGCLn",
-                    displayName: "Project Monitoring Admin",
+                    id: "mKKNXzeIAJs",
+                    displayName: "Data Management Admin",
                     access: "rw------",
                 },
             ],
@@ -1520,8 +1520,8 @@ const expectedMetadataPost = {
                     access: "rw------",
                 },
                 {
-                    id: "KAQv2ZlGCLn",
-                    displayName: "Project Monitoring Admin",
+                    id: "mKKNXzeIAJs",
+                    displayName: "Data Management Admin",
                     access: "rw------",
                 },
             ],
@@ -1618,8 +1618,8 @@ const expectedMetadataPost = {
                     access: "rw------",
                 },
                 {
-                    id: "KAQv2ZlGCLn",
-                    displayName: "Project Monitoring Admin",
+                    id: "mKKNXzeIAJs",
+                    displayName: "Data Management Admin",
                     access: "rw------",
                 },
             ],
@@ -1706,38 +1706,38 @@ const expectedMetadataPost = {
                     id: "pe",
                 },
                 {
-                    id: "a0Cy1qwUuZv",
+                    id: "uSMHdwhxFSV",
                     categoryOptions: [
                         {
                             code: "NEW",
-                            id: "S2y8dcmR2kD",
+                            id: "KiK0FMExoqh",
                             categoryOptionCombos: [
                                 {
-                                    id: "UU2P0YSJM8A",
+                                    id: "aoRpDH3cNkD",
                                 },
                                 {
-                                    id: "bOokLlHM9no",
+                                    id: "kYnK9rhdUYO",
                                 },
                                 {
-                                    id: "kx33GL2khoi",
+                                    id: "KB5Mfe7zpOw",
                                 },
                                 {
-                                    id: "nwv02VfyQuz",
+                                    id: "RZeJX0Tg9Tx",
                                 },
                             ],
                         },
                     ],
                 },
             ],
-            filterDimensions: ["ou", "pe", "a0Cy1qwUuZv"],
+            filterDimensions: ["ou", "pe", "uSMHdwhxFSV"],
             categoryDimensions: [
                 {
                     category: {
-                        id: "a0Cy1qwUuZv",
+                        id: "uSMHdwhxFSV",
                     },
                     categoryOptions: [
                         {
-                            id: "S2y8dcmR2kD",
+                            id: "KiK0FMExoqh",
                         },
                     ],
                 },
@@ -1765,8 +1765,8 @@ const expectedMetadataPost = {
                     access: "rw------",
                 },
                 {
-                    id: "KAQv2ZlGCLn",
-                    displayName: "Project Monitoring Admin",
+                    id: "mKKNXzeIAJs",
+                    displayName: "Data Management Admin",
                     access: "rw------",
                 },
             ],
@@ -1839,8 +1839,8 @@ const expectedMetadataPost = {
                     access: "rw------",
                 },
                 {
-                    id: "KAQv2ZlGCLn",
-                    displayName: "Project Monitoring Admin",
+                    id: "mKKNXzeIAJs",
+                    displayName: "Data Management Admin",
                     access: "rw------",
                 },
             ],

--- a/src/models/__tests__/ProjectDb.spec.ts
+++ b/src/models/__tests__/ProjectDb.spec.ts
@@ -46,7 +46,7 @@ describe("ProjectDb", () => {
             mock.onPut("/organisationUnits/WGC0DJ0YSis", expectedOrgUnitPut).replyOnce(200);
 
             mock.onPut(
-                "/dataStore/project-monitoring-app/project-WGC0DJ0YSis",
+                "/dataStore/data-management-app/project-WGC0DJ0YSis",
                 expectedDataStoreMer
             ).replyOnce(200);
 

--- a/src/models/__tests__/ProjectDownload.spec.ts
+++ b/src/models/__tests__/ProjectDownload.spec.ts
@@ -6,6 +6,7 @@ import { getProject } from "./project-data";
 import moment from "moment";
 import analyticsPeopleResponse from "./data/project-download-people-analytics.json";
 import analyticsBenefitsResponse from "./data/project-download-benefits-analytics.json";
+import { logUnknownRequest } from "../../utils/tests";
 
 const { api, mock } = getMockApi();
 
@@ -24,7 +25,7 @@ describe("ProjectDownload", () => {
                         "pe:202001;202002;202003;202004",
                         "dx:WS8XV4WWPE7;K6mAC5SiO29;ik0ICagvIjm;yMqK9DKbA3X;GQyudNlGzkI",
                         "GIIHAr9BzzO",
-                        "a0Cy1qwUuZv",
+                        "uSMHdwhxFSV",
                         "Kyg1O6YEGa9",
                     ],
                 },
@@ -40,6 +41,8 @@ describe("ProjectDownload", () => {
                     ],
                 },
             }).replyOnce(200, analyticsBenefitsResponse);
+
+            logUnknownRequest(mock);
 
             project = getProject(api, {
                 startDate: moment("2020-01-01"),

--- a/src/models/__tests__/User.spec.ts
+++ b/src/models/__tests__/User.spec.ts
@@ -4,7 +4,7 @@ import config from "./config";
 
 describe("User permissions", () => {
     it("Admin can perform all actions", () => {
-        const adminConfig = getConfigForUserWithRole("PM Admin");
+        const adminConfig = getConfigForUserWithRole("DM Admin");
         const user = new User(adminConfig);
 
         expect(user.hasRole("admin")).toBe(true);

--- a/src/models/__tests__/config.json
+++ b/src/models/__tests__/config.json
@@ -20,7 +20,7 @@
         },
         "attributes": {
             "pairedDataElement": "PM_PAIRED_DE",
-            "createdByApp": "PM_CREATED_BY_PROJECT_MONITORING",
+            "createdByApp": "PM_CREATED_BY_DATA_MANAGEMENT",
             "orgUnitProject": "PM_ORGUNIT_PROJECT_ID",
             "projectDashboard": "PM_PROJECT_DASHBOARD_ID",
             "countingMethod": "PM_COUNTING_METHOD",
@@ -72,7 +72,7 @@
         },
         "userGroups": {
             "systemAdmin": "SYSTEM_ADMIN",
-            "appAdmin": "PROJECT_MONITORING_ADMIN",
+            "appAdmin": "DATA_MANAGEMENT_ADMIN",
             "countryAdminPrefix": "ADMIN_COUNTRY_"
         }
     },
@@ -86,7 +86,7 @@
                     "name": "PM Admin"
                 },
                 {
-                    "name": "METADATA_SYNC_SHOW_DELETED_OBJECTS"
+                    "name": "Metadata Maintainer"
                 },
                 {
                     "name": "Superuser"
@@ -104,8 +104,78 @@
             },
             {
                 "level": 2,
+                "id": "aqWKqMN5pUb",
+                "displayName": "Vietnam"
+            },
+            {
+                "level": 2,
+                "id": "iiqkef8z9uo",
+                "displayName": "Bolivia"
+            },
+            {
+                "level": 2,
+                "id": "uAsAoB72yOf",
+                "displayName": "Uganda"
+            },
+            {
+                "level": 2,
+                "id": "OIjEJaV8fWc",
+                "displayName": "Iraq"
+            },
+            {
+                "level": 2,
+                "id": "iwiydbbuiUs",
+                "displayName": "Cambodia"
+            },
+            {
+                "level": 2,
+                "id": "WmczKCGK8FQ",
+                "displayName": "Niger"
+            },
+            {
+                "level": 2,
                 "id": "OKQDUzFwGoC",
                 "displayName": "Philippines"
+            },
+            {
+                "level": 2,
+                "id": "aSgRoxyXeX8",
+                "displayName": "Colombia"
+            },
+            {
+                "level": 2,
+                "id": "So8QA5eT1Oy",
+                "displayName": "Kenya"
+            },
+            {
+                "level": 2,
+                "id": "Sm8vKiwUPie",
+                "displayName": "Ethiopia"
+            },
+            {
+                "level": 2,
+                "id": "S6mKzbkq02p",
+                "displayName": "Liberia"
+            },
+            {
+                "level": 2,
+                "id": "Ww8TTOdRxf7",
+                "displayName": "South Sudan"
+            },
+            {
+                "level": 2,
+                "id": "WOUvEv46NeR",
+                "displayName": "DRC"
+            },
+            {
+                "level": 2,
+                "id": "ugQ7vNtTtdY",
+                "displayName": "Haiti"
+            },
+            {
+                "level": 2,
+                "id": "muOqfsK4cMw",
+                "displayName": "Myanmar"
             }
         ],
         "userRoles": [
@@ -113,7 +183,7 @@
                 "name": "PM Admin"
             },
             {
-                "name": "METADATA_SYNC_SHOW_DELETED_OBJECTS"
+                "name": "Metadata Maintainer"
             },
             {
                 "name": "Superuser"
@@ -131,61 +201,13 @@
             "displayName": "Agriculture",
             "dataElements": [
                 {
+                    "id": "SeYl64icyGD"
+                },
+                {
                     "id": "akYJbGDrNVm"
                 },
                 {
                     "id": "WS8XV4WWPE7"
-                },
-                {
-                    "id": "y2uyhyc7kqW"
-                },
-                {
-                    "id": "K6mAC5SiO29"
-                },
-                {
-                    "id": "m0OkH08ROjX"
-                },
-                {
-                    "id": "KSKcmBgYrov"
-                },
-                {
-                    "id": "uG8477tQT0d"
-                },
-                {
-                    "id": "Wgd2n77F7Gt"
-                },
-                {
-                    "id": "i0wZ2ZFmfkW"
-                },
-                {
-                    "id": "K4ai530ChFX"
-                },
-                {
-                    "id": "Ou41h46tMcD"
-                },
-                {
-                    "id": "mEY5CsRrI0P"
-                },
-                {
-                    "id": "O0QXE8gn0OL"
-                },
-                {
-                    "id": "KecRLspBj0V"
-                },
-                {
-                    "id": "yqiqScaSAPi"
-                },
-                {
-                    "id": "e8Cw6hUXmT3"
-                },
-                {
-                    "id": "C0QLSs6ymHL"
-                },
-                {
-                    "id": "ik0ICagvIjm"
-                },
-                {
-                    "id": "SeYl64icyGD"
                 },
                 {
                     "id": "qCqieUNUMCb"
@@ -200,19 +222,49 @@
                     "id": "SaUjrYpA3ZK"
                 },
                 {
+                    "id": "y2uyhyc7kqW"
+                },
+                {
+                    "id": "K6mAC5SiO29"
+                },
+                {
+                    "id": "m0OkH08ROjX"
+                },
+                {
+                    "id": "uG8477tQT0d"
+                },
+                {
+                    "id": "KSKcmBgYrov"
+                },
+                {
                     "id": "KuMdSyum1NF"
+                },
+                {
+                    "id": "Wgd2n77F7Gt"
                 },
                 {
                     "id": "OIimwtgdcW8"
                 },
                 {
+                    "id": "i0wZ2ZFmfkW"
+                },
+                {
+                    "id": "K4ai530ChFX"
+                },
+                {
+                    "id": "Ou41h46tMcD"
+                },
+                {
                     "id": "yKXntYu2GKF"
                 },
                 {
-                    "id": "esCSTOzV5CD"
+                    "id": "mEY5CsRrI0P"
                 },
                 {
                     "id": "q8C2wnYFK3T"
+                },
+                {
+                    "id": "esCSTOzV5CD"
                 },
                 {
                     "id": "aOUffyMug7t"
@@ -224,10 +276,13 @@
                     "id": "GYYltkqzWlI"
                 },
                 {
-                    "id": "KgETkXKU36b"
+                    "id": "O0QXE8gn0OL"
                 },
                 {
                     "id": "mog7WefRWEM"
+                },
+                {
+                    "id": "KgETkXKU36b"
                 },
                 {
                     "id": "aWmCNZi0Hcq"
@@ -239,19 +294,34 @@
                     "id": "qQy0N1xdwQ1"
                 },
                 {
+                    "id": "KecRLspBj0V"
+                },
+                {
                     "id": "aqCOXJ5URiL"
+                },
+                {
+                    "id": "yqiqScaSAPi"
                 },
                 {
                     "id": "SQKAXCQeTyN"
                 },
                 {
+                    "id": "e8Cw6hUXmT3"
+                },
+                {
                     "id": "e87Q0bPAPFJ"
+                },
+                {
+                    "id": "C0QLSs6ymHL"
                 },
                 {
                     "id": "K4s5c1UqChK"
                 },
                 {
                     "id": "KocDGQNwOVN"
+                },
+                {
+                    "id": "ik0ICagvIjm"
                 }
             ]
         },
@@ -292,25 +362,25 @@
                     "id": "em64U7iG9nf"
                 },
                 {
-                    "id": "WmauKiAiueX"
-                },
-                {
-                    "id": "eYMalffxy0L"
-                },
-                {
-                    "id": "awsNtaiPxBR"
-                },
-                {
-                    "id": "ysU7uKQJf1T"
-                },
-                {
                     "id": "m8UnBobumQc"
                 },
                 {
                     "id": "eYIJJrOJ0JT"
                 },
                 {
+                    "id": "WmauKiAiueX"
+                },
+                {
+                    "id": "eYMalffxy0L"
+                },
+                {
                     "id": "GAKypUThMRr"
+                },
+                {
+                    "id": "awsNtaiPxBR"
+                },
+                {
+                    "id": "ysU7uKQJf1T"
                 },
                 {
                     "id": "qK4YkTO0rZL"
@@ -412,10 +482,10 @@
                     "id": "qeAkV6WFTeu"
                 },
                 {
-                    "id": "qoyCmL8q7xt"
+                    "id": "K6kd4hRr1kH"
                 },
                 {
-                    "id": "K6kd4hRr1kH"
+                    "id": "qoyCmL8q7xt"
                 },
                 {
                     "id": "mmej5Mq3wbX"
@@ -430,10 +500,10 @@
                     "id": "GQwfJqqncbi"
                 },
                 {
-                    "id": "WySskSIZwaM"
+                    "id": "KO8WSTdUWpm"
                 },
                 {
-                    "id": "KO8WSTdUWpm"
+                    "id": "WySskSIZwaM"
                 },
                 {
                     "id": "yCE8yRRSLao"
@@ -466,22 +536,22 @@
                     "id": "SysxWzx4KXX"
                 },
                 {
-                    "id": "SKkfrCzpoxa"
-                },
-                {
                     "id": "y4ApFxWXBfl"
                 },
                 {
                     "id": "uUmy1Go3hhk"
                 },
                 {
+                    "id": "SKkfrCzpoxa"
+                },
+                {
                     "id": "S2ua4bjQVBz"
                 },
                 {
-                    "id": "OKAHBIGz0Ki"
+                    "id": "Wq0MmYQKeZu"
                 },
                 {
-                    "id": "Wq0MmYQKeZu"
+                    "id": "OKAHBIGz0Ki"
                 },
                 {
                     "id": "yqcXYH5BZhD"
@@ -517,10 +587,10 @@
                     "id": "ys6d9CavDJy"
                 },
                 {
-                    "id": "maolqzbs4K3"
+                    "id": "Ck0YFFjEoyo"
                 },
                 {
-                    "id": "Ck0YFFjEoyo"
+                    "id": "maolqzbs4K3"
                 },
                 {
                     "id": "iSUjjR1nolD"
@@ -535,10 +605,10 @@
                     "id": "Gc65mD3LGEp"
                 },
                 {
-                    "id": "maoLtUEhHCC"
+                    "id": "qWykpPAsJe9"
                 },
                 {
-                    "id": "qWykpPAsJe9"
+                    "id": "maoLtUEhHCC"
                 },
                 {
                     "id": "Wayu8KYftDj"
@@ -556,10 +626,10 @@
                     "id": "W0SCUw6KViC"
                 },
                 {
-                    "id": "OwG0d1xRQzS"
+                    "id": "umeoo1RP3HI"
                 },
                 {
-                    "id": "umeoo1RP3HI"
+                    "id": "OwG0d1xRQzS"
                 },
                 {
                     "id": "ussN3RsUlG9"
@@ -580,10 +650,10 @@
                     "id": "uOYLykMs3nd"
                 },
                 {
-                    "id": "qesC4uvl9Ah"
+                    "id": "mwoRWmp5FQc"
                 },
                 {
-                    "id": "mwoRWmp5FQc"
+                    "id": "qesC4uvl9Ah"
                 },
                 {
                     "id": "mu2b9Ivde6J"
@@ -652,10 +722,10 @@
                     "id": "eoEtWMiPJ54"
                 },
                 {
-                    "id": "Co00LfH1Jnk"
+                    "id": "mI0SRjrLyXT"
                 },
                 {
-                    "id": "mI0SRjrLyXT"
+                    "id": "Co00LfH1Jnk"
                 },
                 {
                     "id": "CeUzDYi7iSt"
@@ -682,10 +752,10 @@
                     "id": "ya21TqO05jE"
                 },
                 {
-                    "id": "WUItTX5YzPL"
+                    "id": "ugA5YKLmYfV"
                 },
                 {
-                    "id": "ugA5YKLmYfV"
+                    "id": "WUItTX5YzPL"
                 },
                 {
                     "id": "ec8AkoYUWiA"
@@ -718,10 +788,10 @@
                     "id": "yGIr6ZotIs8"
                 },
                 {
-                    "id": "e0MfXUf9Kqq"
+                    "id": "ySUrbPZBI3d"
                 },
                 {
-                    "id": "ySUrbPZBI3d"
+                    "id": "e0MfXUf9Kqq"
                 },
                 {
                     "id": "aw6FV833DML"
@@ -821,13 +891,13 @@
                     "id": "uk6vjgubPaA"
                 },
                 {
-                    "id": "iyAnflVLHS3"
-                },
-                {
                     "id": "Wq0oITH2wna"
                 },
                 {
                     "id": "eGKS3DrQcTd"
+                },
+                {
+                    "id": "iyAnflVLHS3"
                 },
                 {
                     "id": "yMqK9DKbA3X"
@@ -873,10 +943,10 @@
                     "id": "maolqzbs4K3"
                 },
                 {
-                    "id": "CI8NCm34d7D"
+                    "id": "GeGEm2k6WKy"
                 },
                 {
-                    "id": "GeGEm2k6WKy"
+                    "id": "CI8NCm34d7D"
                 },
                 {
                     "id": "GsKksqhBDzS"
@@ -912,10 +982,10 @@
                     "id": "Ks4y2ZCBejU"
                 },
                 {
-                    "id": "Cg4c5HRdyJt"
+                    "id": "WUMjtbgofs2"
                 },
                 {
-                    "id": "WUMjtbgofs2"
+                    "id": "Cg4c5HRdyJt"
                 },
                 {
                     "id": "ecAfQfpTsfJ"
@@ -952,6 +1022,9 @@
                     "id": "S4gTBFCkNox"
                 },
                 {
+                    "id": "me0ILSeLpfv"
+                },
+                {
                     "id": "em6hBeB1Mgx"
                 },
                 {
@@ -961,73 +1034,22 @@
                     "id": "ei0GG8tgs3O"
                 },
                 {
-                    "id": "qeGgLr2I471"
+                    "id": "uqoHFB0TTNE"
                 },
                 {
-                    "id": "qoyCmL8q7xt"
+                    "id": "WGYVTfvRQTp"
+                },
+                {
+                    "id": "qeGgLr2I471"
                 },
                 {
                     "id": "umgzhNhZZuG"
                 },
                 {
+                    "id": "qoyCmL8q7xt"
+                },
+                {
                     "id": "SiIlD6JXwrh"
-                },
-                {
-                    "id": "CukJJn0tlAe"
-                },
-                {
-                    "id": "WIsDaZNKhVY"
-                },
-                {
-                    "id": "aEWqGOerMCR"
-                },
-                {
-                    "id": "eQCEGPuzi8U"
-                },
-                {
-                    "id": "mSspV1RxrUv"
-                },
-                {
-                    "id": "igegpsgZJtk"
-                },
-                {
-                    "id": "WM8jnuXBsFM"
-                },
-                {
-                    "id": "qcSsqXKZW0U"
-                },
-                {
-                    "id": "KuAjqeAm3ud"
-                },
-                {
-                    "id": "uk6vjgubPaA"
-                },
-                {
-                    "id": "aSyPclS5UKs"
-                },
-                {
-                    "id": "Oocne32yGqU"
-                },
-                {
-                    "id": "SiKGyiSSH6D"
-                },
-                {
-                    "id": "CQkzkkkzpRT"
-                },
-                {
-                    "id": "S60gcORJg7s"
-                },
-                {
-                    "id": "mc7d96pQsmj"
-                },
-                {
-                    "id": "me0ILSeLpfv"
-                },
-                {
-                    "id": "uqoHFB0TTNE"
-                },
-                {
-                    "id": "WGYVTfvRQTp"
                 },
                 {
                     "id": "iMio9osPejA"
@@ -1039,10 +1061,28 @@
                     "id": "q0YJ8y0Cx17"
                 },
                 {
+                    "id": "CukJJn0tlAe"
+                },
+                {
                     "id": "esCSTOzV5CD"
                 },
                 {
+                    "id": "WIsDaZNKhVY"
+                },
+                {
+                    "id": "eQCEGPuzi8U"
+                },
+                {
+                    "id": "aEWqGOerMCR"
+                },
+                {
+                    "id": "mSspV1RxrUv"
+                },
+                {
                     "id": "mKsNDllOoX6"
+                },
+                {
+                    "id": "igegpsgZJtk"
                 },
                 {
                     "id": "mUXPq3PNjxt"
@@ -1054,10 +1094,19 @@
                     "id": "SOgtZvFvRe7"
                 },
                 {
+                    "id": "WM8jnuXBsFM"
+                },
+                {
                     "id": "usUXZo8S6ML"
                 },
                 {
                     "id": "OE5jU8FBwjN"
+                },
+                {
+                    "id": "qcSsqXKZW0U"
+                },
+                {
+                    "id": "KuAjqeAm3ud"
                 },
                 {
                     "id": "WEgNESq1A7p"
@@ -1066,10 +1115,31 @@
                     "id": "eusRdnJsPYS"
                 },
                 {
+                    "id": "uk6vjgubPaA"
+                },
+                {
+                    "id": "aSyPclS5UKs"
+                },
+                {
                     "id": "WmMjbrn9L5N"
                 },
                 {
+                    "id": "Oocne32yGqU"
+                },
+                {
+                    "id": "SiKGyiSSH6D"
+                },
+                {
                     "id": "GqglcVtN0jK"
+                },
+                {
+                    "id": "S60gcORJg7s"
+                },
+                {
+                    "id": "CQkzkkkzpRT"
+                },
+                {
+                    "id": "mc7d96pQsmj"
                 },
                 {
                     "id": "WMaSv1ifNYB"
@@ -1175,10 +1245,10 @@
                     "id": "qua6NsVc0NK"
                 },
                 {
-                    "id": "SGiIDNhFovM"
+                    "id": "KSk0xFTWOnV"
                 },
                 {
-                    "id": "KSk0xFTWOnV"
+                    "id": "SGiIDNhFovM"
                 },
                 {
                     "id": "qM69VnOH5U7"
@@ -1229,10 +1299,10 @@
                     "id": "Omobz0poEAJ"
                 },
                 {
-                    "id": "qCaKOh97pu5"
+                    "id": "mK8Ix4mGY4D"
                 },
                 {
-                    "id": "mK8Ix4mGY4D"
+                    "id": "qCaKOh97pu5"
                 },
                 {
                     "id": "aEM7IlLGKAs"
@@ -1266,10 +1336,10 @@
                     "id": "qYmi5h7nMi5"
                 },
                 {
-                    "id": "KueoAZr2xIV"
+                    "id": "uoaCYzmXcE8"
                 },
                 {
-                    "id": "uoaCYzmXcE8"
+                    "id": "KueoAZr2xIV"
                 },
                 {
                     "id": "Wmquc4R3BkI"
@@ -1314,10 +1384,10 @@
                     "id": "Ky6VzmlyzCj"
                 },
                 {
-                    "id": "ywQfPB6FJCu"
+                    "id": "yIgnPUbwsLS"
                 },
                 {
-                    "id": "yIgnPUbwsLS"
+                    "id": "ywQfPB6FJCu"
                 },
                 {
                     "id": "yqmyP1vNJk0"
@@ -1326,10 +1396,10 @@
                     "id": "OSOCkyUnh9m"
                 },
                 {
-                    "id": "CQEv5mMFQwk"
+                    "id": "CAoDnDrYQ5S"
                 },
                 {
-                    "id": "CAoDnDrYQ5S"
+                    "id": "CQEv5mMFQwk"
                 },
                 {
                     "id": "OIisZWsbUWF"
@@ -1344,10 +1414,10 @@
                     "id": "iCKxYSFIlcu"
                 },
                 {
-                    "id": "qcwhkIgx56S"
+                    "id": "Sy02tbklwzs"
                 },
                 {
-                    "id": "Sy02tbklwzs"
+                    "id": "qcwhkIgx56S"
                 },
                 {
                     "id": "yKY8IwqOAdj"
@@ -1384,16 +1454,40 @@
                     "id": "mu2b9Ivde6J"
                 },
                 {
+                    "id": "aYk5MgSCLXP"
+                },
+                {
                     "id": "qY6VZUiUqP5"
                 },
                 {
-                    "id": "aYk5MgSCLXP"
+                    "id": "maolqzbs4K3"
+                },
+                {
+                    "id": "eCiNhTEEwP2"
+                },
+                {
+                    "id": "mgSMcRjQY7P"
+                },
+                {
+                    "id": "KWmKf2Tlg6p"
+                },
+                {
+                    "id": "qYMiVPnxFpT"
                 },
                 {
                     "id": "uyErryPGFZs"
                 },
                 {
-                    "id": "KWmKf2Tlg6p"
+                    "id": "miYneg7nVZR"
+                },
+                {
+                    "id": "mm8STQA7P0V"
+                },
+                {
+                    "id": "KKmUWsn19fq"
+                },
+                {
+                    "id": "muknsuxQ5ch"
                 },
                 {
                     "id": "ayKUg0jcQIs"
@@ -1405,6 +1499,9 @@
                     "id": "OKgFYITeL5k"
                 },
                 {
+                    "id": "CQK2WzuEktG"
+                },
+                {
                     "id": "OOCOr95zk1q"
                 },
                 {
@@ -1412,6 +1509,12 @@
                 },
                 {
                     "id": "S6oNywvqVL9"
+                },
+                {
+                    "id": "CE9te39HtIt"
+                },
+                {
+                    "id": "Okq8Qfhx8Yn"
                 },
                 {
                     "id": "uQeZCfhxIAZ"
@@ -1432,70 +1535,25 @@
                     "id": "OYiIfLFNIBU"
                 },
                 {
-                    "id": "Gg4qCBvZ99L"
+                    "id": "G6CCgEB6NLt"
                 },
                 {
-                    "id": "G6CCgEB6NLt"
+                    "id": "Gg4qCBvZ99L"
                 },
                 {
                     "id": "qsyWwrmt33M"
                 },
                 {
-                    "id": "imuTP7oBnOF"
-                },
-                {
-                    "id": "iYEDR850FFL"
-                },
-                {
-                    "id": "W4sDeNJ86rf"
-                },
-                {
-                    "id": "CQPwg8Nipro"
-                },
-                {
-                    "id": "qCc9Mog86QE"
-                },
-                {
-                    "id": "maolqzbs4K3"
-                },
-                {
-                    "id": "eCiNhTEEwP2"
-                },
-                {
-                    "id": "mgSMcRjQY7P"
-                },
-                {
-                    "id": "miYneg7nVZR"
-                },
-                {
-                    "id": "qYMiVPnxFpT"
-                },
-                {
-                    "id": "mm8STQA7P0V"
-                },
-                {
-                    "id": "KKmUWsn19fq"
-                },
-                {
-                    "id": "muknsuxQ5ch"
-                },
-                {
-                    "id": "CQK2WzuEktG"
-                },
-                {
-                    "id": "CE9te39HtIt"
-                },
-                {
-                    "id": "Okq8Qfhx8Yn"
-                },
-                {
                     "id": "OI2puJwy7Q6"
+                },
+                {
+                    "id": "m6QynUevAqo"
                 },
                 {
                     "id": "OwUrgV6dRRD"
                 },
                 {
-                    "id": "m6QynUevAqo"
+                    "id": "imuTP7oBnOF"
                 },
                 {
                     "id": "ecAfQfpTsfJ"
@@ -1516,7 +1574,19 @@
                     "id": "SImQCbjEbXz"
                 },
                 {
+                    "id": "W4sDeNJ86rf"
+                },
+                {
                     "id": "WwuQyH1Y38R"
+                },
+                {
+                    "id": "iYEDR850FFL"
+                },
+                {
+                    "id": "CQPwg8Nipro"
+                },
+                {
+                    "id": "qCc9Mog86QE"
                 }
             ]
         },
@@ -1526,10 +1596,10 @@
             "displayName": "WASH",
             "dataElements": [
                 {
-                    "id": "mkOo1Ano2Te"
+                    "id": "OYkHOXijR2y"
                 },
                 {
-                    "id": "OYkHOXijR2y"
+                    "id": "mkOo1Ano2Te"
                 },
                 {
                     "id": "qkamQF5GoMT"
@@ -1538,10 +1608,10 @@
                     "id": "qow7I4mkB1o"
                 },
                 {
-                    "id": "Ws48eBlsPVy"
+                    "id": "meUNtJr7X5M"
                 },
                 {
-                    "id": "meUNtJr7X5M"
+                    "id": "Ws48eBlsPVy"
                 },
                 {
                     "id": "SuayUhAd7I9"
@@ -1571,10 +1641,10 @@
                     "id": "qm6HENhtZpz"
                 },
                 {
-                    "id": "Oacl33jhIKS"
+                    "id": "aE0itK0vaKD"
                 },
                 {
-                    "id": "aE0itK0vaKD"
+                    "id": "Oacl33jhIKS"
                 },
                 {
                     "id": "mSGEH8Rhe8n"
@@ -1589,10 +1659,10 @@
                     "id": "ieMPt2lJ3lp"
                 },
                 {
-                    "id": "GeIvUs41E1U"
+                    "id": "uyMhgwLwrzi"
                 },
                 {
-                    "id": "uyMhgwLwrzi"
+                    "id": "GeIvUs41E1U"
                 },
                 {
                     "id": "SiCifbteVub"
@@ -1610,13 +1680,13 @@
                     "id": "G8CuZodHu5I"
                 },
                 {
-                    "id": "a08FKV0iidX"
+                    "id": "Ce4u0MTUype"
                 },
                 {
                     "id": "e6grCpK5iSl"
                 },
                 {
-                    "id": "Ce4u0MTUype"
+                    "id": "a08FKV0iidX"
                 },
                 {
                     "id": "C6Ip0lKUOBv"
@@ -1694,19 +1764,19 @@
                     "id": "m02VdFteqEH"
                 },
                 {
-                    "id": "ecQncxEhoEE"
+                    "id": "qgqARJdCR8V"
                 },
                 {
-                    "id": "qgqARJdCR8V"
+                    "id": "ecQncxEhoEE"
                 },
                 {
                     "id": "SUXD2Xh8jJn"
                 },
                 {
-                    "id": "mM6TxfM7fqL"
+                    "id": "SM6Sz5h0fsL"
                 },
                 {
-                    "id": "SM6Sz5h0fsL"
+                    "id": "mM6TxfM7fqL"
                 },
                 {
                     "id": "uE6ZPpbPz66"
@@ -1754,7 +1824,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -1844,7 +1914,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -1902,7 +1972,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -1928,7 +1998,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -2026,7 +2096,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -2052,7 +2122,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -2110,7 +2180,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -2136,7 +2206,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -2162,7 +2232,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -2188,7 +2258,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -2214,7 +2284,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -2240,7 +2310,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -2362,7 +2432,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -2388,7 +2458,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -2418,7 +2488,59 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "Wq0oITH2wna",
+            "name": "de-P020303",
+            "code": "P020303",
+            "externalsDescription": "",
+            "description": "de-description-P020303",
+            "sectorsInfo": [
+                {
+                    "id": "GkiSljtLcOI",
+                    "series": "203"
+                }
+            ],
+            "mainSector": {
+                "id": "GkiSljtLcOI"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "eGKS3DrQcTd",
+            "name": "de-P020312",
+            "code": "P020312",
+            "externalsDescription": "",
+            "description": "de-description-P020312",
+            "sectorsInfo": [
+                {
+                    "id": "GkiSljtLcOI",
+                    "series": "203"
+                }
+            ],
+            "mainSector": {
+                "id": "GkiSljtLcOI"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -2452,58 +2574,6 @@
             "categoryCombo": {
                 "id": "bjDvmb4bfuf",
                 "displayName": "None"
-            },
-            "selectable": true
-        },
-        {
-            "id": "Wq0oITH2wna",
-            "name": "de-P020303",
-            "code": "P020303",
-            "externalsDescription": "",
-            "description": "de-description-P020303",
-            "sectorsInfo": [
-                {
-                    "id": "GkiSljtLcOI",
-                    "series": "203"
-                }
-            ],
-            "mainSector": {
-                "id": "GkiSljtLcOI"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "eGKS3DrQcTd",
-            "name": "de-P020312",
-            "code": "P020312",
-            "externalsDescription": "",
-            "description": "de-description-P020312",
-            "sectorsInfo": [
-                {
-                    "id": "GkiSljtLcOI",
-                    "series": "203"
-                }
-            ],
-            "mainSector": {
-                "id": "GkiSljtLcOI"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
             },
             "selectable": true
         },
@@ -2628,7 +2698,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -2654,7 +2724,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -2680,7 +2750,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -2714,8 +2784,34 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "SeYl64icyGD",
+            "name": "de-B010205",
+            "code": "B010205",
+            "externalsDescription": "",
+            "description": "de-description-B010205",
+            "sectorsInfo": [
+                {
+                    "id": "ieyBABjYyHO",
+                    "series": "102"
+                }
+            ],
+            "mainSector": {
+                "id": "ieyBABjYyHO"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "benefit",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "bjDvmb4bfuf",
+                "displayName": "None"
             },
             "selectable": true
         },
@@ -2740,7 +2836,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -2761,434 +2857,6 @@
                 "id": "ieyBABjYyHO"
             },
             "indicatorType": "global",
-            "peopleOrBenefit": "benefit",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "bjDvmb4bfuf",
-                "displayName": "None"
-            },
-            "selectable": true
-        },
-        {
-            "id": "y2uyhyc7kqW",
-            "name": "de-B010003",
-            "code": "B010003",
-            "externalsDescription": "",
-            "description": "de-description-B010003",
-            "sectorsInfo": [
-                {
-                    "id": "ieyBABjYyHO",
-                    "series": "100"
-                }
-            ],
-            "mainSector": {
-                "id": "ieyBABjYyHO"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "benefit",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "bjDvmb4bfuf",
-                "displayName": "None"
-            },
-            "selectable": true
-        },
-        {
-            "id": "K6mAC5SiO29",
-            "name": "de-P010100",
-            "code": "P010100",
-            "externalsDescription": "OFDA, DFID",
-            "description": "de-description-P010100",
-            "sectorsInfo": [
-                {
-                    "id": "ieyBABjYyHO",
-                    "series": "101"
-                }
-            ],
-            "mainSector": {
-                "id": "ieyBABjYyHO"
-            },
-            "indicatorType": "global",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": ["DFID", "OFDA"],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "m0OkH08ROjX",
-            "name": "de-P010405",
-            "code": "P010405",
-            "externalsDescription": "",
-            "description": "de-description-P010405",
-            "sectorsInfo": [
-                {
-                    "id": "ieyBABjYyHO",
-                    "series": "104"
-                }
-            ],
-            "mainSector": {
-                "id": "ieyBABjYyHO"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "KSKcmBgYrov",
-            "name": "de-P010109",
-            "code": "P010109",
-            "externalsDescription": "UNHCR",
-            "description": "de-description-P010109",
-            "sectorsInfo": [
-                {
-                    "id": "ieyBABjYyHO",
-                    "series": "101"
-                }
-            ],
-            "mainSector": {
-                "id": "ieyBABjYyHO"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": ["UNHCR"],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "uG8477tQT0d",
-            "name": "de-P010103",
-            "code": "P010103",
-            "externalsDescription": "",
-            "description": "de-description-P010103",
-            "sectorsInfo": [
-                {
-                    "id": "ieyBABjYyHO",
-                    "series": "101"
-                }
-            ],
-            "mainSector": {
-                "id": "ieyBABjYyHO"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "Wgd2n77F7Gt",
-            "name": "de-B010302",
-            "code": "B010302",
-            "externalsDescription": "DFID",
-            "description": "de-description-B010302",
-            "sectorsInfo": [
-                {
-                    "id": "ieyBABjYyHO",
-                    "series": "103"
-                }
-            ],
-            "mainSector": {
-                "id": "ieyBABjYyHO"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "benefit",
-            "pairedDataElements": [
-                {
-                    "id": "akYJbGDrNVm",
-                    "code": "P010402",
-                    "name": "pde-P010402"
-                }
-            ],
-            "countingMethod": "",
-            "externals": ["DFID"],
-            "categoryCombo": {
-                "id": "bjDvmb4bfuf",
-                "displayName": "None"
-            },
-            "selectable": true
-        },
-        {
-            "id": "K4ai530ChFX",
-            "name": "de-P010002",
-            "code": "P010002",
-            "externalsDescription": "",
-            "description": "de-description-P010002",
-            "sectorsInfo": [
-                {
-                    "id": "ieyBABjYyHO",
-                    "series": "100"
-                }
-            ],
-            "mainSector": {
-                "id": "ieyBABjYyHO"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "Ou41h46tMcD",
-            "name": "de-P010107",
-            "code": "P010107",
-            "externalsDescription": "",
-            "description": "de-description-P010107",
-            "sectorsInfo": [
-                {
-                    "id": "ieyBABjYyHO",
-                    "series": "101"
-                }
-            ],
-            "mainSector": {
-                "id": "ieyBABjYyHO"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "mEY5CsRrI0P",
-            "name": "de-P010111",
-            "code": "P010111",
-            "externalsDescription": "",
-            "description": "de-description-P010111",
-            "sectorsInfo": [
-                {
-                    "id": "ieyBABjYyHO",
-                    "series": "101"
-                }
-            ],
-            "mainSector": {
-                "id": "ieyBABjYyHO"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "O0QXE8gn0OL",
-            "name": "de-P010404",
-            "code": "P010404",
-            "externalsDescription": "",
-            "description": "de-description-P010404",
-            "sectorsInfo": [
-                {
-                    "id": "ieyBABjYyHO",
-                    "series": "104"
-                }
-            ],
-            "mainSector": {
-                "id": "ieyBABjYyHO"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "KecRLspBj0V",
-            "name": "de-P010104",
-            "code": "P010104",
-            "externalsDescription": "OFDA",
-            "description": "de-description-P010104",
-            "sectorsInfo": [
-                {
-                    "id": "ieyBABjYyHO",
-                    "series": "101"
-                }
-            ],
-            "mainSector": {
-                "id": "ieyBABjYyHO"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": ["OFDA"],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "yqiqScaSAPi",
-            "name": "de-B010301",
-            "code": "B010301",
-            "externalsDescription": "",
-            "description": "de-description-B010301",
-            "sectorsInfo": [
-                {
-                    "id": "ieyBABjYyHO",
-                    "series": "103"
-                }
-            ],
-            "mainSector": {
-                "id": "ieyBABjYyHO"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "benefit",
-            "pairedDataElements": [
-                {
-                    "id": "SaUjrYpA3ZK",
-                    "code": "P010401",
-                    "name": "pde-P010401"
-                }
-            ],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "bjDvmb4bfuf",
-                "displayName": "None"
-            },
-            "selectable": true
-        },
-        {
-            "id": "e8Cw6hUXmT3",
-            "name": "de-P010403",
-            "code": "P010403",
-            "externalsDescription": "",
-            "description": "de-description-P010403",
-            "sectorsInfo": [
-                {
-                    "id": "ieyBABjYyHO",
-                    "series": "104"
-                }
-            ],
-            "mainSector": {
-                "id": "ieyBABjYyHO"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "C0QLSs6ymHL",
-            "name": "de-P010102",
-            "code": "P010102",
-            "externalsDescription": "UNHCR",
-            "description": "de-description-P010102",
-            "sectorsInfo": [
-                {
-                    "id": "ieyBABjYyHO",
-                    "series": "101"
-                }
-            ],
-            "mainSector": {
-                "id": "ieyBABjYyHO"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": ["UNHCR"],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "ik0ICagvIjm",
-            "name": "de-P010101",
-            "code": "P010101",
-            "externalsDescription": "GAC, UNHCR",
-            "description": "de-description-P010101",
-            "sectorsInfo": [
-                {
-                    "id": "ieyBABjYyHO",
-                    "series": "101"
-                }
-            ],
-            "mainSector": {
-                "id": "ieyBABjYyHO"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": ["GAC", "UNHCR"],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "SeYl64icyGD",
-            "name": "de-B010205",
-            "code": "B010205",
-            "externalsDescription": "",
-            "description": "de-description-B010205",
-            "sectorsInfo": [
-                {
-                    "id": "ieyBABjYyHO",
-                    "series": "102"
-                }
-            ],
-            "mainSector": {
-                "id": "ieyBABjYyHO"
-            },
-            "indicatorType": "sub",
             "peopleOrBenefit": "benefit",
             "pairedDataElements": [],
             "countingMethod": "",
@@ -3246,7 +2914,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -3298,7 +2966,137 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "y2uyhyc7kqW",
+            "name": "de-B010003",
+            "code": "B010003",
+            "externalsDescription": "",
+            "description": "de-description-B010003",
+            "sectorsInfo": [
+                {
+                    "id": "ieyBABjYyHO",
+                    "series": "100"
+                }
+            ],
+            "mainSector": {
+                "id": "ieyBABjYyHO"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "benefit",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "bjDvmb4bfuf",
+                "displayName": "None"
+            },
+            "selectable": true
+        },
+        {
+            "id": "K6mAC5SiO29",
+            "name": "de-P010100",
+            "code": "P010100",
+            "externalsDescription": "OFDA, DFID",
+            "description": "de-description-P010100",
+            "sectorsInfo": [
+                {
+                    "id": "ieyBABjYyHO",
+                    "series": "101"
+                }
+            ],
+            "mainSector": {
+                "id": "ieyBABjYyHO"
+            },
+            "indicatorType": "global",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": ["DFID", "OFDA"],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "m0OkH08ROjX",
+            "name": "de-P010405",
+            "code": "P010405",
+            "externalsDescription": "",
+            "description": "de-description-P010405",
+            "sectorsInfo": [
+                {
+                    "id": "ieyBABjYyHO",
+                    "series": "104"
+                }
+            ],
+            "mainSector": {
+                "id": "ieyBABjYyHO"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "uG8477tQT0d",
+            "name": "de-P010103",
+            "code": "P010103",
+            "externalsDescription": "",
+            "description": "de-description-P010103",
+            "sectorsInfo": [
+                {
+                    "id": "ieyBABjYyHO",
+                    "series": "101"
+                }
+            ],
+            "mainSector": {
+                "id": "ieyBABjYyHO"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "KSKcmBgYrov",
+            "name": "de-P010109",
+            "code": "P010109",
+            "externalsDescription": "UNHCR",
+            "description": "de-description-P010109",
+            "sectorsInfo": [
+                {
+                    "id": "ieyBABjYyHO",
+                    "series": "101"
+                }
+            ],
+            "mainSector": {
+                "id": "ieyBABjYyHO"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": ["UNHCR"],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -3323,6 +3121,38 @@
             "pairedDataElements": [],
             "countingMethod": "",
             "externals": [],
+            "categoryCombo": {
+                "id": "bjDvmb4bfuf",
+                "displayName": "None"
+            },
+            "selectable": true
+        },
+        {
+            "id": "Wgd2n77F7Gt",
+            "name": "de-B010302",
+            "code": "B010302",
+            "externalsDescription": "DFID",
+            "description": "de-description-B010302",
+            "sectorsInfo": [
+                {
+                    "id": "ieyBABjYyHO",
+                    "series": "103"
+                }
+            ],
+            "mainSector": {
+                "id": "ieyBABjYyHO"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "benefit",
+            "pairedDataElements": [
+                {
+                    "id": "akYJbGDrNVm",
+                    "code": "P010402",
+                    "name": "pde-P010402"
+                }
+            ],
+            "countingMethod": "",
+            "externals": ["DFID"],
             "categoryCombo": {
                 "id": "bjDvmb4bfuf",
                 "displayName": "None"
@@ -3362,6 +3192,58 @@
             "selectable": true
         },
         {
+            "id": "K4ai530ChFX",
+            "name": "de-P010002",
+            "code": "P010002",
+            "externalsDescription": "",
+            "description": "de-description-P010002",
+            "sectorsInfo": [
+                {
+                    "id": "ieyBABjYyHO",
+                    "series": "100"
+                }
+            ],
+            "mainSector": {
+                "id": "ieyBABjYyHO"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "Ou41h46tMcD",
+            "name": "de-P010107",
+            "code": "P010107",
+            "externalsDescription": "",
+            "description": "de-description-P010107",
+            "sectorsInfo": [
+                {
+                    "id": "ieyBABjYyHO",
+                    "series": "101"
+                }
+            ],
+            "mainSector": {
+                "id": "ieyBABjYyHO"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
             "id": "yKXntYu2GKF",
             "name": "de-B010303",
             "code": "B010303",
@@ -3385,6 +3267,58 @@
                     "name": "pde-P010403"
                 }
             ],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "bjDvmb4bfuf",
+                "displayName": "None"
+            },
+            "selectable": true
+        },
+        {
+            "id": "mEY5CsRrI0P",
+            "name": "de-P010111",
+            "code": "P010111",
+            "externalsDescription": "",
+            "description": "de-description-P010111",
+            "sectorsInfo": [
+                {
+                    "id": "ieyBABjYyHO",
+                    "series": "101"
+                }
+            ],
+            "mainSector": {
+                "id": "ieyBABjYyHO"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "q8C2wnYFK3T",
+            "name": "de-B010204",
+            "code": "B010204",
+            "externalsDescription": "",
+            "description": "de-description-B010204",
+            "sectorsInfo": [
+                {
+                    "id": "ieyBABjYyHO",
+                    "series": "102"
+                }
+            ],
+            "mainSector": {
+                "id": "ieyBABjYyHO"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "benefit",
+            "pairedDataElements": [],
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
@@ -3424,32 +3358,6 @@
             "selectable": true
         },
         {
-            "id": "q8C2wnYFK3T",
-            "name": "de-B010204",
-            "code": "B010204",
-            "externalsDescription": "",
-            "description": "de-description-B010204",
-            "sectorsInfo": [
-                {
-                    "id": "ieyBABjYyHO",
-                    "series": "102"
-                }
-            ],
-            "mainSector": {
-                "id": "ieyBABjYyHO"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "benefit",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "bjDvmb4bfuf",
-                "displayName": "None"
-            },
-            "selectable": true
-        },
-        {
             "id": "aOUffyMug7t",
             "name": "de-P010110",
             "code": "P010110",
@@ -3470,7 +3378,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -3522,8 +3430,60 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "O0QXE8gn0OL",
+            "name": "de-P010404",
+            "code": "P010404",
+            "externalsDescription": "",
+            "description": "de-description-P010404",
+            "sectorsInfo": [
+                {
+                    "id": "ieyBABjYyHO",
+                    "series": "104"
+                }
+            ],
+            "mainSector": {
+                "id": "ieyBABjYyHO"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "mog7WefRWEM",
+            "name": "de-B010001",
+            "code": "B010001",
+            "externalsDescription": "",
+            "description": "de-description-B010001",
+            "sectorsInfo": [
+                {
+                    "id": "ieyBABjYyHO",
+                    "series": "100"
+                }
+            ],
+            "mainSector": {
+                "id": "ieyBABjYyHO"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "benefit",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "bjDvmb4bfuf",
+                "displayName": "None"
             },
             "selectable": true
         },
@@ -3551,32 +3511,6 @@
                     "name": "pde-P010405"
                 }
             ],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "bjDvmb4bfuf",
-                "displayName": "None"
-            },
-            "selectable": true
-        },
-        {
-            "id": "mog7WefRWEM",
-            "name": "de-B010001",
-            "code": "B010001",
-            "externalsDescription": "",
-            "description": "de-description-B010001",
-            "sectorsInfo": [
-                {
-                    "id": "ieyBABjYyHO",
-                    "series": "100"
-                }
-            ],
-            "mainSector": {
-                "id": "ieyBABjYyHO"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "benefit",
-            "pairedDataElements": [],
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
@@ -3670,7 +3604,33 @@
             "countingMethod": "",
             "externals": ["WFP"],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "KecRLspBj0V",
+            "name": "de-P010104",
+            "code": "P010104",
+            "externalsDescription": "OFDA",
+            "description": "de-description-P010104",
+            "sectorsInfo": [
+                {
+                    "id": "ieyBABjYyHO",
+                    "series": "101"
+                }
+            ],
+            "mainSector": {
+                "id": "ieyBABjYyHO"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": ["OFDA"],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -3696,8 +3656,40 @@
             "countingMethod": "",
             "externals": ["DFID"],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "yqiqScaSAPi",
+            "name": "de-B010301",
+            "code": "B010301",
+            "externalsDescription": "",
+            "description": "de-description-B010301",
+            "sectorsInfo": [
+                {
+                    "id": "ieyBABjYyHO",
+                    "series": "103"
+                }
+            ],
+            "mainSector": {
+                "id": "ieyBABjYyHO"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "benefit",
+            "pairedDataElements": [
+                {
+                    "id": "SaUjrYpA3ZK",
+                    "code": "P010401",
+                    "name": "pde-P010401"
+                }
+            ],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "bjDvmb4bfuf",
+                "displayName": "None"
             },
             "selectable": true
         },
@@ -3734,6 +3726,32 @@
             "selectable": true
         },
         {
+            "id": "e8Cw6hUXmT3",
+            "name": "de-P010403",
+            "code": "P010403",
+            "externalsDescription": "",
+            "description": "de-description-P010403",
+            "sectorsInfo": [
+                {
+                    "id": "ieyBABjYyHO",
+                    "series": "104"
+                }
+            ],
+            "mainSector": {
+                "id": "ieyBABjYyHO"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
             "id": "e87Q0bPAPFJ",
             "name": "de-P010106",
             "code": "P010106",
@@ -3754,7 +3772,33 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "C0QLSs6ymHL",
+            "name": "de-P010102",
+            "code": "P010102",
+            "externalsDescription": "UNHCR",
+            "description": "de-description-P010102",
+            "sectorsInfo": [
+                {
+                    "id": "ieyBABjYyHO",
+                    "series": "101"
+                }
+            ],
+            "mainSector": {
+                "id": "ieyBABjYyHO"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": ["UNHCR"],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -3780,7 +3824,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -3806,7 +3850,33 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "ik0ICagvIjm",
+            "name": "de-P010101",
+            "code": "P010101",
+            "externalsDescription": "GAC, UNHCR",
+            "description": "de-description-P010101",
+            "sectorsInfo": [
+                {
+                    "id": "ieyBABjYyHO",
+                    "series": "101"
+                }
+            ],
+            "mainSector": {
+                "id": "ieyBABjYyHO"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": ["GAC", "UNHCR"],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -3858,7 +3928,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -3888,7 +3958,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -3950,7 +4020,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -3976,7 +4046,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -4002,7 +4072,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -4032,7 +4102,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -4062,7 +4132,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -4152,7 +4222,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -4280,7 +4350,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -4306,7 +4376,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -4332,7 +4402,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -4390,7 +4460,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -4422,6 +4492,32 @@
             "selectable": true
         },
         {
+            "id": "me0ILSeLpfv",
+            "name": "de-P040205",
+            "code": "P040205",
+            "externalsDescription": "",
+            "description": "de-description-P040205",
+            "sectorsInfo": [
+                {
+                    "id": "mUmeTWQ7qvZ",
+                    "series": "402"
+                }
+            ],
+            "mainSector": {
+                "id": "mUmeTWQ7qvZ"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
             "id": "em6hBeB1Mgx",
             "name": "de-P040506",
             "code": "P040506",
@@ -4442,7 +4538,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -4468,7 +4564,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -4494,453 +4590,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "qoyCmL8q7xt",
-            "name": "de-P060106",
-            "code": "P060106",
-            "externalsDescription": "",
-            "description": "de-description-P060106",
-            "sectorsInfo": [
-                {
-                    "id": "mUmeTWQ7qvZ",
-                    "series": "403"
-                },
-                {
-                    "id": "m6wRIr4gijM",
-                    "series": "601"
-                }
-            ],
-            "mainSector": {
-                "id": "m6wRIr4gijM"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "umgzhNhZZuG",
-            "name": "de-P040103",
-            "code": "P040103",
-            "externalsDescription": "",
-            "description": "de-description-P040103",
-            "sectorsInfo": [
-                {
-                    "id": "mUmeTWQ7qvZ",
-                    "series": "401"
-                }
-            ],
-            "mainSector": {
-                "id": "mUmeTWQ7qvZ"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "SiIlD6JXwrh",
-            "name": "de-P040208",
-            "code": "P040208",
-            "externalsDescription": "",
-            "description": "de-description-P040208",
-            "sectorsInfo": [
-                {
-                    "id": "mUmeTWQ7qvZ",
-                    "series": "402"
-                }
-            ],
-            "mainSector": {
-                "id": "mUmeTWQ7qvZ"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "CukJJn0tlAe",
-            "name": "de-B040004",
-            "code": "B040004",
-            "externalsDescription": "",
-            "description": "de-description-B040004",
-            "sectorsInfo": [
-                {
-                    "id": "mUmeTWQ7qvZ",
-                    "series": "400"
-                }
-            ],
-            "mainSector": {
-                "id": "mUmeTWQ7qvZ"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "benefit",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "bjDvmb4bfuf",
-                "displayName": "None"
-            },
-            "selectable": true
-        },
-        {
-            "id": "WIsDaZNKhVY",
-            "name": "de-P040104",
-            "code": "P040104",
-            "externalsDescription": "",
-            "description": "de-description-P040104",
-            "sectorsInfo": [
-                {
-                    "id": "mUmeTWQ7qvZ",
-                    "series": "401"
-                }
-            ],
-            "mainSector": {
-                "id": "mUmeTWQ7qvZ"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "aEWqGOerMCR",
-            "name": "de-P040206",
-            "code": "P040206",
-            "externalsDescription": "",
-            "description": "de-description-P040206",
-            "sectorsInfo": [
-                {
-                    "id": "mUmeTWQ7qvZ",
-                    "series": "402"
-                }
-            ],
-            "mainSector": {
-                "id": "mUmeTWQ7qvZ"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "eQCEGPuzi8U",
-            "name": "de-B040301",
-            "code": "B040301",
-            "externalsDescription": "",
-            "description": "de-description-B040301",
-            "sectorsInfo": [
-                {
-                    "id": "mUmeTWQ7qvZ",
-                    "series": "403"
-                }
-            ],
-            "mainSector": {
-                "id": "mUmeTWQ7qvZ"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "benefit",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "bjDvmb4bfuf",
-                "displayName": "None"
-            },
-            "selectable": true
-        },
-        {
-            "id": "mSspV1RxrUv",
-            "name": "de-P040105",
-            "code": "P040105",
-            "externalsDescription": "",
-            "description": "de-description-P040105",
-            "sectorsInfo": [
-                {
-                    "id": "mUmeTWQ7qvZ",
-                    "series": "401"
-                }
-            ],
-            "mainSector": {
-                "id": "mUmeTWQ7qvZ"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "igegpsgZJtk",
-            "name": "de-P040507",
-            "code": "P040507",
-            "externalsDescription": "",
-            "description": "de-description-P040507",
-            "sectorsInfo": [
-                {
-                    "id": "mUmeTWQ7qvZ",
-                    "series": "405"
-                }
-            ],
-            "mainSector": {
-                "id": "mUmeTWQ7qvZ"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "WM8jnuXBsFM",
-            "name": "de-P040201",
-            "code": "P040201",
-            "externalsDescription": "",
-            "description": "de-description-P040201",
-            "sectorsInfo": [
-                {
-                    "id": "mUmeTWQ7qvZ",
-                    "series": "402"
-                }
-            ],
-            "mainSector": {
-                "id": "mUmeTWQ7qvZ"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "KuAjqeAm3ud",
-            "name": "de-P040100",
-            "code": "P040100",
-            "externalsDescription": "",
-            "description": "de-description-P040100",
-            "sectorsInfo": [
-                {
-                    "id": "mUmeTWQ7qvZ",
-                    "series": "401"
-                }
-            ],
-            "mainSector": {
-                "id": "mUmeTWQ7qvZ"
-            },
-            "indicatorType": "global",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "aSyPclS5UKs",
-            "name": "de-B040003",
-            "code": "B040003",
-            "externalsDescription": "",
-            "description": "de-description-B040003",
-            "sectorsInfo": [
-                {
-                    "id": "mUmeTWQ7qvZ",
-                    "series": "400"
-                }
-            ],
-            "mainSector": {
-                "id": "mUmeTWQ7qvZ"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "benefit",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "bjDvmb4bfuf",
-                "displayName": "None"
-            },
-            "selectable": true
-        },
-        {
-            "id": "Oocne32yGqU",
-            "name": "de-P040503",
-            "code": "P040503",
-            "externalsDescription": "",
-            "description": "de-description-P040503",
-            "sectorsInfo": [
-                {
-                    "id": "mUmeTWQ7qvZ",
-                    "series": "405"
-                }
-            ],
-            "mainSector": {
-                "id": "mUmeTWQ7qvZ"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "SiKGyiSSH6D",
-            "name": "de-P040107",
-            "code": "P040107",
-            "externalsDescription": "",
-            "description": "de-description-P040107",
-            "sectorsInfo": [
-                {
-                    "id": "mUmeTWQ7qvZ",
-                    "series": "401"
-                }
-            ],
-            "mainSector": {
-                "id": "mUmeTWQ7qvZ"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "S60gcORJg7s",
-            "name": "de-P040401",
-            "code": "P040401",
-            "externalsDescription": "",
-            "description": "de-description-P040401",
-            "sectorsInfo": [
-                {
-                    "id": "mUmeTWQ7qvZ",
-                    "series": "404"
-                }
-            ],
-            "mainSector": {
-                "id": "mUmeTWQ7qvZ"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "mc7d96pQsmj",
-            "name": "de-P040508",
-            "code": "P040508",
-            "externalsDescription": "",
-            "description": "de-description-P040508",
-            "sectorsInfo": [
-                {
-                    "id": "mUmeTWQ7qvZ",
-                    "series": "405"
-                }
-            ],
-            "mainSector": {
-                "id": "mUmeTWQ7qvZ"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "me0ILSeLpfv",
-            "name": "de-P040205",
-            "code": "P040205",
-            "externalsDescription": "",
-            "description": "de-description-P040205",
-            "sectorsInfo": [
-                {
-                    "id": "mUmeTWQ7qvZ",
-                    "series": "402"
-                }
-            ],
-            "mainSector": {
-                "id": "mUmeTWQ7qvZ"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -4992,7 +4642,89 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "umgzhNhZZuG",
+            "name": "de-P040103",
+            "code": "P040103",
+            "externalsDescription": "",
+            "description": "de-description-P040103",
+            "sectorsInfo": [
+                {
+                    "id": "mUmeTWQ7qvZ",
+                    "series": "401"
+                }
+            ],
+            "mainSector": {
+                "id": "mUmeTWQ7qvZ"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "qoyCmL8q7xt",
+            "name": "de-P060106",
+            "code": "P060106",
+            "externalsDescription": "",
+            "description": "de-description-P060106",
+            "sectorsInfo": [
+                {
+                    "id": "mUmeTWQ7qvZ",
+                    "series": "403"
+                },
+                {
+                    "id": "m6wRIr4gijM",
+                    "series": "601"
+                }
+            ],
+            "mainSector": {
+                "id": "m6wRIr4gijM"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "SiIlD6JXwrh",
+            "name": "de-P040208",
+            "code": "P040208",
+            "externalsDescription": "",
+            "description": "de-description-P040208",
+            "sectorsInfo": [
+                {
+                    "id": "mUmeTWQ7qvZ",
+                    "series": "402"
+                }
+            ],
+            "mainSector": {
+                "id": "mUmeTWQ7qvZ"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -5018,7 +4750,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -5044,7 +4776,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -5070,7 +4802,137 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "CukJJn0tlAe",
+            "name": "de-B040004",
+            "code": "B040004",
+            "externalsDescription": "",
+            "description": "de-description-B040004",
+            "sectorsInfo": [
+                {
+                    "id": "mUmeTWQ7qvZ",
+                    "series": "400"
+                }
+            ],
+            "mainSector": {
+                "id": "mUmeTWQ7qvZ"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "benefit",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "bjDvmb4bfuf",
+                "displayName": "None"
+            },
+            "selectable": true
+        },
+        {
+            "id": "WIsDaZNKhVY",
+            "name": "de-P040104",
+            "code": "P040104",
+            "externalsDescription": "",
+            "description": "de-description-P040104",
+            "sectorsInfo": [
+                {
+                    "id": "mUmeTWQ7qvZ",
+                    "series": "401"
+                }
+            ],
+            "mainSector": {
+                "id": "mUmeTWQ7qvZ"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "eQCEGPuzi8U",
+            "name": "de-B040301",
+            "code": "B040301",
+            "externalsDescription": "",
+            "description": "de-description-B040301",
+            "sectorsInfo": [
+                {
+                    "id": "mUmeTWQ7qvZ",
+                    "series": "403"
+                }
+            ],
+            "mainSector": {
+                "id": "mUmeTWQ7qvZ"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "benefit",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "bjDvmb4bfuf",
+                "displayName": "None"
+            },
+            "selectable": true
+        },
+        {
+            "id": "aEWqGOerMCR",
+            "name": "de-P040206",
+            "code": "P040206",
+            "externalsDescription": "",
+            "description": "de-description-P040206",
+            "sectorsInfo": [
+                {
+                    "id": "mUmeTWQ7qvZ",
+                    "series": "402"
+                }
+            ],
+            "mainSector": {
+                "id": "mUmeTWQ7qvZ"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "mSspV1RxrUv",
+            "name": "de-P040105",
+            "code": "P040105",
+            "externalsDescription": "",
+            "description": "de-description-P040105",
+            "sectorsInfo": [
+                {
+                    "id": "mUmeTWQ7qvZ",
+                    "series": "401"
+                }
+            ],
+            "mainSector": {
+                "id": "mUmeTWQ7qvZ"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -5096,7 +4958,33 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "igegpsgZJtk",
+            "name": "de-P040507",
+            "code": "P040507",
+            "externalsDescription": "",
+            "description": "de-description-P040507",
+            "sectorsInfo": [
+                {
+                    "id": "mUmeTWQ7qvZ",
+                    "series": "405"
+                }
+            ],
+            "mainSector": {
+                "id": "mUmeTWQ7qvZ"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -5122,7 +5010,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -5148,7 +5036,33 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "WM8jnuXBsFM",
+            "name": "de-P040201",
+            "code": "P040201",
+            "externalsDescription": "",
+            "description": "de-description-P040201",
+            "sectorsInfo": [
+                {
+                    "id": "mUmeTWQ7qvZ",
+                    "series": "402"
+                }
+            ],
+            "mainSector": {
+                "id": "mUmeTWQ7qvZ"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -5174,7 +5088,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -5200,7 +5114,33 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "KuAjqeAm3ud",
+            "name": "de-P040100",
+            "code": "P040100",
+            "externalsDescription": "",
+            "description": "de-description-P040100",
+            "sectorsInfo": [
+                {
+                    "id": "mUmeTWQ7qvZ",
+                    "series": "401"
+                }
+            ],
+            "mainSector": {
+                "id": "mUmeTWQ7qvZ"
+            },
+            "indicatorType": "global",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -5226,7 +5166,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -5252,8 +5192,34 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "aSyPclS5UKs",
+            "name": "de-B040003",
+            "code": "B040003",
+            "externalsDescription": "",
+            "description": "de-description-B040003",
+            "sectorsInfo": [
+                {
+                    "id": "mUmeTWQ7qvZ",
+                    "series": "400"
+                }
+            ],
+            "mainSector": {
+                "id": "mUmeTWQ7qvZ"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "benefit",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "bjDvmb4bfuf",
+                "displayName": "None"
             },
             "selectable": true
         },
@@ -5278,7 +5244,59 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "Oocne32yGqU",
+            "name": "de-P040503",
+            "code": "P040503",
+            "externalsDescription": "",
+            "description": "de-description-P040503",
+            "sectorsInfo": [
+                {
+                    "id": "mUmeTWQ7qvZ",
+                    "series": "405"
+                }
+            ],
+            "mainSector": {
+                "id": "mUmeTWQ7qvZ"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "SiKGyiSSH6D",
+            "name": "de-P040107",
+            "code": "P040107",
+            "externalsDescription": "",
+            "description": "de-description-P040107",
+            "sectorsInfo": [
+                {
+                    "id": "mUmeTWQ7qvZ",
+                    "series": "401"
+                }
+            ],
+            "mainSector": {
+                "id": "mUmeTWQ7qvZ"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -5304,7 +5322,59 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "S60gcORJg7s",
+            "name": "de-P040401",
+            "code": "P040401",
+            "externalsDescription": "",
+            "description": "de-description-P040401",
+            "sectorsInfo": [
+                {
+                    "id": "mUmeTWQ7qvZ",
+                    "series": "404"
+                }
+            ],
+            "mainSector": {
+                "id": "mUmeTWQ7qvZ"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "mc7d96pQsmj",
+            "name": "de-P040508",
+            "code": "P040508",
+            "externalsDescription": "",
+            "description": "de-description-P040508",
+            "sectorsInfo": [
+                {
+                    "id": "mUmeTWQ7qvZ",
+                    "series": "405"
+                }
+            ],
+            "mainSector": {
+                "id": "mUmeTWQ7qvZ"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -5330,7 +5400,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -5356,7 +5426,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -5450,7 +5520,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -5572,7 +5642,33 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "KO8WSTdUWpm",
+            "name": "de-P060911",
+            "code": "P060911",
+            "externalsDescription": "",
+            "description": "de-description-P060911",
+            "sectorsInfo": [
+                {
+                    "id": "m6wRIr4gijM",
+                    "series": "609"
+                }
+            ],
+            "mainSector": {
+                "id": "m6wRIr4gijM"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -5610,32 +5706,6 @@
             "selectable": true
         },
         {
-            "id": "KO8WSTdUWpm",
-            "name": "de-P060911",
-            "code": "P060911",
-            "externalsDescription": "",
-            "description": "de-description-P060911",
-            "sectorsInfo": [
-                {
-                    "id": "m6wRIr4gijM",
-                    "series": "609"
-                }
-            ],
-            "mainSector": {
-                "id": "m6wRIr4gijM"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
             "id": "yCE8yRRSLao",
             "name": "de-P060103",
             "code": "P060103",
@@ -5656,7 +5726,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -5682,7 +5752,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -5712,7 +5782,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -5802,7 +5872,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -5828,7 +5898,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -5886,7 +5956,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -5912,40 +5982,8 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "SKkfrCzpoxa",
-            "name": "de-B060301",
-            "code": "B060301",
-            "externalsDescription": "",
-            "description": "de-description-B060301",
-            "sectorsInfo": [
-                {
-                    "id": "m6wRIr4gijM",
-                    "series": "603"
-                }
-            ],
-            "mainSector": {
-                "id": "m6wRIr4gijM"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "benefit",
-            "pairedDataElements": [
-                {
-                    "id": "iQYbMelX1S1",
-                    "code": "P060401",
-                    "name": "pde-P060401"
-                }
-            ],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "bjDvmb4bfuf",
-                "displayName": "None"
             },
             "selectable": true
         },
@@ -6002,8 +6040,40 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "SKkfrCzpoxa",
+            "name": "de-B060301",
+            "code": "B060301",
+            "externalsDescription": "",
+            "description": "de-description-B060301",
+            "sectorsInfo": [
+                {
+                    "id": "m6wRIr4gijM",
+                    "series": "603"
+                }
+            ],
+            "mainSector": {
+                "id": "m6wRIr4gijM"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "benefit",
+            "pairedDataElements": [
+                {
+                    "id": "iQYbMelX1S1",
+                    "code": "P060401",
+                    "name": "pde-P060401"
+                }
+            ],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "bjDvmb4bfuf",
+                "displayName": "None"
             },
             "selectable": true
         },
@@ -6040,32 +6110,6 @@
             "selectable": true
         },
         {
-            "id": "OKAHBIGz0Ki",
-            "name": "de-P060104",
-            "code": "P060104",
-            "externalsDescription": "",
-            "description": "de-description-P060104",
-            "sectorsInfo": [
-                {
-                    "id": "m6wRIr4gijM",
-                    "series": "601"
-                }
-            ],
-            "mainSector": {
-                "id": "m6wRIr4gijM"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
             "id": "Wq0MmYQKeZu",
             "name": "de-B061002",
             "code": "B061002",
@@ -6098,6 +6142,32 @@
             "selectable": true
         },
         {
+            "id": "OKAHBIGz0Ki",
+            "name": "de-P060104",
+            "code": "P060104",
+            "externalsDescription": "",
+            "description": "de-description-P060104",
+            "sectorsInfo": [
+                {
+                    "id": "m6wRIr4gijM",
+                    "series": "601"
+                }
+            ],
+            "mainSector": {
+                "id": "m6wRIr4gijM"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
             "id": "yqcXYH5BZhD",
             "name": "de-P061110",
             "code": "P061110",
@@ -6118,7 +6188,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -6144,7 +6214,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -6170,7 +6240,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -6260,7 +6330,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -6286,7 +6356,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -6344,7 +6414,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -6370,7 +6440,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -6408,6 +6478,32 @@
             "selectable": true
         },
         {
+            "id": "Ck0YFFjEoyo",
+            "name": "de-P060608",
+            "code": "P060608",
+            "externalsDescription": "",
+            "description": "de-description-P060608",
+            "sectorsInfo": [
+                {
+                    "id": "m6wRIr4gijM",
+                    "series": "606"
+                }
+            ],
+            "mainSector": {
+                "id": "m6wRIr4gijM"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
             "id": "maolqzbs4K3",
             "name": "de-P081601",
             "code": "P081601",
@@ -6436,33 +6532,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "Ck0YFFjEoyo",
-            "name": "de-P060608",
-            "code": "P060608",
-            "externalsDescription": "",
-            "description": "de-description-P060608",
-            "sectorsInfo": [
-                {
-                    "id": "m6wRIr4gijM",
-                    "series": "606"
-                }
-            ],
-            "mainSector": {
-                "id": "m6wRIr4gijM"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -6520,7 +6590,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -6590,32 +6660,6 @@
             "selectable": true
         },
         {
-            "id": "maoLtUEhHCC",
-            "name": "de-P060403",
-            "code": "P060403",
-            "externalsDescription": "",
-            "description": "de-description-P060403",
-            "sectorsInfo": [
-                {
-                    "id": "m6wRIr4gijM",
-                    "series": "604"
-                }
-            ],
-            "mainSector": {
-                "id": "m6wRIr4gijM"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
             "id": "qWykpPAsJe9",
             "name": "de-B060500",
             "code": "B060500",
@@ -6648,6 +6692,32 @@
             "selectable": true
         },
         {
+            "id": "maoLtUEhHCC",
+            "name": "de-P060403",
+            "code": "P060403",
+            "externalsDescription": "",
+            "description": "de-description-P060403",
+            "sectorsInfo": [
+                {
+                    "id": "m6wRIr4gijM",
+                    "series": "604"
+                }
+            ],
+            "mainSector": {
+                "id": "m6wRIr4gijM"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
             "id": "Wayu8KYftDj",
             "name": "de-P060404",
             "code": "P060404",
@@ -6668,7 +6738,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -6720,7 +6790,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -6778,33 +6848,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "OwG0d1xRQzS",
-            "name": "de-P061103",
-            "code": "P061103",
-            "externalsDescription": "",
-            "description": "de-description-P061103",
-            "sectorsInfo": [
-                {
-                    "id": "m6wRIr4gijM",
-                    "series": "611"
-                }
-            ],
-            "mainSector": {
-                "id": "m6wRIr4gijM"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -6830,7 +6874,33 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "OwG0d1xRQzS",
+            "name": "de-P061103",
+            "code": "P061103",
+            "externalsDescription": "",
+            "description": "de-description-P061103",
+            "sectorsInfo": [
+                {
+                    "id": "m6wRIr4gijM",
+                    "series": "611"
+                }
+            ],
+            "mainSector": {
+                "id": "m6wRIr4gijM"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -6888,7 +6958,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -6978,7 +7048,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -7016,6 +7086,32 @@
             "selectable": true
         },
         {
+            "id": "mwoRWmp5FQc",
+            "name": "de-P060603",
+            "code": "P060603",
+            "externalsDescription": "",
+            "description": "de-description-P060603",
+            "sectorsInfo": [
+                {
+                    "id": "m6wRIr4gijM",
+                    "series": "606"
+                }
+            ],
+            "mainSector": {
+                "id": "m6wRIr4gijM"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
             "id": "qesC4uvl9Ah",
             "name": "de-B060309",
             "code": "B060309",
@@ -7044,32 +7140,6 @@
             "categoryCombo": {
                 "id": "bjDvmb4bfuf",
                 "displayName": "None"
-            },
-            "selectable": true
-        },
-        {
-            "id": "mwoRWmp5FQc",
-            "name": "de-P060603",
-            "code": "P060603",
-            "externalsDescription": "",
-            "description": "de-description-P060603",
-            "sectorsInfo": [
-                {
-                    "id": "m6wRIr4gijM",
-                    "series": "606"
-                }
-            ],
-            "mainSector": {
-                "id": "m6wRIr4gijM"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
             },
             "selectable": true
         },
@@ -7134,7 +7204,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -7160,7 +7230,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -7186,7 +7256,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -7276,7 +7346,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -7306,7 +7376,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -7332,7 +7402,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -7416,7 +7486,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -7442,7 +7512,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -7468,7 +7538,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -7526,7 +7596,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -7552,7 +7622,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -7578,7 +7648,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -7604,7 +7674,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -7630,7 +7700,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -7656,33 +7726,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "Co00LfH1Jnk",
-            "name": "de-P060405",
-            "code": "P060405",
-            "externalsDescription": "",
-            "description": "de-description-P060405",
-            "sectorsInfo": [
-                {
-                    "id": "m6wRIr4gijM",
-                    "series": "604"
-                }
-            ],
-            "mainSector": {
-                "id": "m6wRIr4gijM"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -7708,7 +7752,33 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "Co00LfH1Jnk",
+            "name": "de-P060405",
+            "code": "P060405",
+            "externalsDescription": "",
+            "description": "de-description-P060405",
+            "sectorsInfo": [
+                {
+                    "id": "m6wRIr4gijM",
+                    "series": "604"
+                }
+            ],
+            "mainSector": {
+                "id": "m6wRIr4gijM"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -7774,7 +7844,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -7858,7 +7928,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -7922,32 +7992,6 @@
             "selectable": true
         },
         {
-            "id": "WUItTX5YzPL",
-            "name": "de-P060100",
-            "code": "P060100",
-            "externalsDescription": "",
-            "description": "de-description-P060100",
-            "sectorsInfo": [
-                {
-                    "id": "m6wRIr4gijM",
-                    "series": "601"
-                }
-            ],
-            "mainSector": {
-                "id": "m6wRIr4gijM"
-            },
-            "indicatorType": "global",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
             "id": "ugA5YKLmYfV",
             "name": "de-P060607",
             "code": "P060607",
@@ -7968,7 +8012,33 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "WUItTX5YzPL",
+            "name": "de-P060100",
+            "code": "P060100",
+            "externalsDescription": "",
+            "description": "de-description-P060100",
+            "sectorsInfo": [
+                {
+                    "id": "m6wRIr4gijM",
+                    "series": "601"
+                }
+            ],
+            "mainSector": {
+                "id": "m6wRIr4gijM"
+            },
+            "indicatorType": "global",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -7994,7 +8064,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -8052,7 +8122,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -8078,7 +8148,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -8136,7 +8206,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -8162,7 +8232,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -8188,7 +8258,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -8214,7 +8284,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -8242,6 +8312,32 @@
             "categoryCombo": {
                 "id": "bjDvmb4bfuf",
                 "displayName": "None"
+            },
+            "selectable": true
+        },
+        {
+            "id": "ySUrbPZBI3d",
+            "name": "de-P060903",
+            "code": "P060903",
+            "externalsDescription": "",
+            "description": "de-description-P060903",
+            "sectorsInfo": [
+                {
+                    "id": "m6wRIr4gijM",
+                    "series": "609"
+                }
+            ],
+            "mainSector": {
+                "id": "m6wRIr4gijM"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
             },
             "selectable": true
         },
@@ -8274,32 +8370,6 @@
             "categoryCombo": {
                 "id": "bjDvmb4bfuf",
                 "displayName": "None"
-            },
-            "selectable": true
-        },
-        {
-            "id": "ySUrbPZBI3d",
-            "name": "de-P060903",
-            "code": "P060903",
-            "externalsDescription": "",
-            "description": "de-description-P060903",
-            "sectorsInfo": [
-                {
-                    "id": "m6wRIr4gijM",
-                    "series": "609"
-                }
-            ],
-            "mainSector": {
-                "id": "m6wRIr4gijM"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
             },
             "selectable": true
         },
@@ -8356,7 +8426,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -8454,7 +8524,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -8480,7 +8550,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -8510,8 +8580,40 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "aYk5MgSCLXP",
+            "name": "de-B081200",
+            "code": "B081200",
+            "externalsDescription": "",
+            "description": "de-description-B081200",
+            "sectorsInfo": [
+                {
+                    "id": "O2wdK9G0m9f",
+                    "series": "812"
+                }
+            ],
+            "mainSector": {
+                "id": "O2wdK9G0m9f"
+            },
+            "indicatorType": "global",
+            "peopleOrBenefit": "benefit",
+            "pairedDataElements": [
+                {
+                    "id": "KKmUWsn19fq",
+                    "code": "P081300",
+                    "name": "pde-P081300"
+                }
+            ],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "bjDvmb4bfuf",
+                "displayName": "None"
             },
             "selectable": true
         },
@@ -8552,59 +8654,53 @@
             "selectable": true
         },
         {
-            "id": "aYk5MgSCLXP",
-            "name": "de-B081200",
-            "code": "B081200",
+            "id": "eCiNhTEEwP2",
+            "name": "de-P080800",
+            "code": "P080800",
             "externalsDescription": "",
-            "description": "de-description-B081200",
+            "description": "de-description-P080800",
             "sectorsInfo": [
                 {
                     "id": "O2wdK9G0m9f",
-                    "series": "812"
+                    "series": "808"
                 }
             ],
             "mainSector": {
                 "id": "O2wdK9G0m9f"
             },
             "indicatorType": "global",
-            "peopleOrBenefit": "benefit",
-            "pairedDataElements": [
-                {
-                    "id": "KKmUWsn19fq",
-                    "code": "P081300",
-                    "name": "pde-P081300"
-                }
-            ],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "bjDvmb4bfuf",
-                "displayName": "None"
-            },
-            "selectable": true
-        },
-        {
-            "id": "uyErryPGFZs",
-            "name": "de-P080001",
-            "code": "P080001",
-            "externalsDescription": "",
-            "description": "de-description-P080001",
-            "sectorsInfo": [
-                {
-                    "id": "O2wdK9G0m9f",
-                    "series": "800"
-                }
-            ],
-            "mainSector": {
-                "id": "O2wdK9G0m9f"
-            },
-            "indicatorType": "sub",
             "peopleOrBenefit": "people",
             "pairedDataElements": [],
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "mgSMcRjQY7P",
+            "name": "de-P080600",
+            "code": "P080600",
+            "externalsDescription": "",
+            "description": "de-description-P080600",
+            "sectorsInfo": [
+                {
+                    "id": "O2wdK9G0m9f",
+                    "series": "806"
+                }
+            ],
+            "mainSector": {
+                "id": "O2wdK9G0m9f"
+            },
+            "indicatorType": "global",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -8630,8 +8726,188 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "qYMiVPnxFpT",
+            "name": "de-P030901",
+            "code": "P030901",
+            "externalsDescription": "",
+            "description": "de-description-P030901",
+            "sectorsInfo": [
+                {
+                    "id": "O2wdK9G0m9f",
+                    "series": "800"
+                },
+                {
+                    "id": "Oq4A79YZZ8E",
+                    "series": "309"
+                }
+            ],
+            "mainSector": {
+                "id": "Oq4A79YZZ8E"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "uyErryPGFZs",
+            "name": "de-P080001",
+            "code": "P080001",
+            "externalsDescription": "",
+            "description": "de-description-P080001",
+            "sectorsInfo": [
+                {
+                    "id": "O2wdK9G0m9f",
+                    "series": "800"
+                }
+            ],
+            "mainSector": {
+                "id": "O2wdK9G0m9f"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "miYneg7nVZR",
+            "name": "de-B030001",
+            "code": "B030001",
+            "externalsDescription": "",
+            "description": "de-description-B030001",
+            "sectorsInfo": [
+                {
+                    "id": "O2wdK9G0m9f",
+                    "series": "800"
+                },
+                {
+                    "id": "Oq4A79YZZ8E",
+                    "series": "300"
+                }
+            ],
+            "mainSector": {
+                "id": "Oq4A79YZZ8E"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "benefit",
+            "pairedDataElements": [
+                {
+                    "id": "awgF2cmvQrn",
+                    "code": "P030002",
+                    "name": "pde-P030002"
+                }
+            ],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "bjDvmb4bfuf",
+                "displayName": "None"
+            },
+            "selectable": true
+        },
+        {
+            "id": "mm8STQA7P0V",
+            "name": "de-P070400",
+            "code": "P070400",
+            "externalsDescription": "",
+            "description": "de-description-P070400",
+            "sectorsInfo": [
+                {
+                    "id": "O2wdK9G0m9f",
+                    "series": "800"
+                },
+                {
+                    "id": "i8qug2Himby",
+                    "series": "704"
+                }
+            ],
+            "mainSector": {
+                "id": "i8qug2Himby"
+            },
+            "indicatorType": "global",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "KKmUWsn19fq",
+            "name": "de-P081300",
+            "code": "P081300",
+            "externalsDescription": "",
+            "description": "de-description-P081300",
+            "sectorsInfo": [
+                {
+                    "id": "O2wdK9G0m9f",
+                    "series": "813"
+                }
+            ],
+            "mainSector": {
+                "id": "O2wdK9G0m9f"
+            },
+            "indicatorType": "global",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "muknsuxQ5ch",
+            "name": "de-B081201",
+            "code": "B081201",
+            "externalsDescription": "",
+            "description": "de-description-B081201",
+            "sectorsInfo": [
+                {
+                    "id": "O2wdK9G0m9f",
+                    "series": "812"
+                }
+            ],
+            "mainSector": {
+                "id": "O2wdK9G0m9f"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "benefit",
+            "pairedDataElements": [
+                {
+                    "id": "eSqIjaS1r2w",
+                    "code": "P081301",
+                    "name": "pde-P081301"
+                }
+            ],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "bjDvmb4bfuf",
+                "displayName": "None"
             },
             "selectable": true
         },
@@ -8660,7 +8936,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -8730,6 +9006,38 @@
             "selectable": true
         },
         {
+            "id": "CQK2WzuEktG",
+            "name": "de-B080102",
+            "code": "B080102",
+            "externalsDescription": "",
+            "description": "de-description-B080102",
+            "sectorsInfo": [
+                {
+                    "id": "O2wdK9G0m9f",
+                    "series": "801"
+                }
+            ],
+            "mainSector": {
+                "id": "O2wdK9G0m9f"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "benefit",
+            "pairedDataElements": [
+                {
+                    "id": "qsyWwrmt33M",
+                    "code": "P080202",
+                    "name": "pde-P080202"
+                }
+            ],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "bjDvmb4bfuf",
+                "displayName": "None"
+            },
+            "selectable": true
+        },
+        {
             "id": "OOCOr95zk1q",
             "name": "de-P081305",
             "code": "P081305",
@@ -8750,7 +9058,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -8812,7 +9120,65 @@
             "countingMethod": "",
             "externals": ["OFDA"],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "CE9te39HtIt",
+            "name": "de-B081203",
+            "code": "B081203",
+            "externalsDescription": "",
+            "description": "de-description-B081203",
+            "sectorsInfo": [
+                {
+                    "id": "O2wdK9G0m9f",
+                    "series": "812"
+                }
+            ],
+            "mainSector": {
+                "id": "O2wdK9G0m9f"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "benefit",
+            "pairedDataElements": [
+                {
+                    "id": "iAQ5SzrWRoj",
+                    "code": "P081303",
+                    "name": "pde-P081303"
+                }
+            ],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "bjDvmb4bfuf",
+                "displayName": "None"
+            },
+            "selectable": true
+        },
+        {
+            "id": "Okq8Qfhx8Yn",
+            "name": "de-P081402",
+            "code": "P081402",
+            "externalsDescription": "",
+            "description": "de-description-P081402",
+            "sectorsInfo": [
+                {
+                    "id": "O2wdK9G0m9f",
+                    "series": "814"
+                }
+            ],
+            "mainSector": {
+                "id": "O2wdK9G0m9f"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -8838,7 +9204,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -8894,7 +9260,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -8952,7 +9318,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -8990,32 +9356,6 @@
             "selectable": true
         },
         {
-            "id": "Gg4qCBvZ99L",
-            "name": "de-P081304",
-            "code": "P081304",
-            "externalsDescription": "",
-            "description": "de-description-P081304",
-            "sectorsInfo": [
-                {
-                    "id": "O2wdK9G0m9f",
-                    "series": "813"
-                }
-            ],
-            "mainSector": {
-                "id": "O2wdK9G0m9f"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
             "id": "G6CCgEB6NLt",
             "name": "de-B080103",
             "code": "B080103",
@@ -9048,6 +9388,32 @@
             "selectable": true
         },
         {
+            "id": "Gg4qCBvZ99L",
+            "name": "de-P081304",
+            "code": "P081304",
+            "externalsDescription": "",
+            "description": "de-description-P081304",
+            "sectorsInfo": [
+                {
+                    "id": "O2wdK9G0m9f",
+                    "series": "813"
+                }
+            ],
+            "mainSector": {
+                "id": "O2wdK9G0m9f"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
             "id": "qsyWwrmt33M",
             "name": "de-P080202",
             "code": "P080202",
@@ -9068,7 +9434,91 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "OI2puJwy7Q6",
+            "name": "de-P081100",
+            "code": "P081100",
+            "externalsDescription": "OFDA: Number of HHs having received shelter assistance",
+            "description": "de-description-P081100",
+            "sectorsInfo": [
+                {
+                    "id": "O2wdK9G0m9f",
+                    "series": "811"
+                }
+            ],
+            "mainSector": {
+                "id": "O2wdK9G0m9f"
+            },
+            "indicatorType": "global",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": ["OFDA"],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "m6QynUevAqo",
+            "name": "de-B081205",
+            "code": "B081205",
+            "externalsDescription": "",
+            "description": "de-description-B081205",
+            "sectorsInfo": [
+                {
+                    "id": "O2wdK9G0m9f",
+                    "series": "812"
+                }
+            ],
+            "mainSector": {
+                "id": "O2wdK9G0m9f"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "benefit",
+            "pairedDataElements": [
+                {
+                    "id": "OOCOr95zk1q",
+                    "code": "P081305",
+                    "name": "pde-P081305"
+                }
+            ],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "bjDvmb4bfuf",
+                "displayName": "None"
+            },
+            "selectable": true
+        },
+        {
+            "id": "OwUrgV6dRRD",
+            "name": "de-P080400",
+            "code": "P080400",
+            "externalsDescription": "",
+            "description": "de-description-P080400",
+            "sectorsInfo": [
+                {
+                    "id": "O2wdK9G0m9f",
+                    "series": "804"
+                }
+            ],
+            "mainSector": {
+                "id": "O2wdK9G0m9f"
+            },
+            "indicatorType": "global",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -9095,6 +9545,146 @@
                     "id": "uQeZCfhxIAZ",
                     "code": "P081302",
                     "name": "pde-P081302"
+                }
+            ],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "bjDvmb4bfuf",
+                "displayName": "None"
+            },
+            "selectable": true
+        },
+        {
+            "id": "KAqED5puVJR",
+            "name": "de-P080200",
+            "code": "P080200",
+            "externalsDescription": "",
+            "description": "de-description-P080200",
+            "sectorsInfo": [
+                {
+                    "id": "O2wdK9G0m9f",
+                    "series": "802"
+                }
+            ],
+            "mainSector": {
+                "id": "O2wdK9G0m9f"
+            },
+            "indicatorType": "global",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "eSqIjaS1r2w",
+            "name": "de-P081301",
+            "code": "P081301",
+            "externalsDescription": "",
+            "description": "de-description-P081301",
+            "sectorsInfo": [
+                {
+                    "id": "O2wdK9G0m9f",
+                    "series": "813"
+                }
+            ],
+            "mainSector": {
+                "id": "O2wdK9G0m9f"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "iAQ5SzrWRoj",
+            "name": "de-P081303",
+            "code": "P081303",
+            "externalsDescription": "",
+            "description": "de-description-P081303",
+            "sectorsInfo": [
+                {
+                    "id": "O2wdK9G0m9f",
+                    "series": "813"
+                }
+            ],
+            "mainSector": {
+                "id": "O2wdK9G0m9f"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "awgF2cmvQrn",
+            "name": "de-P030002",
+            "code": "P030002",
+            "externalsDescription": "",
+            "description": "de-description-P030002",
+            "sectorsInfo": [
+                {
+                    "id": "O2wdK9G0m9f",
+                    "series": "800"
+                },
+                {
+                    "id": "Oq4A79YZZ8E",
+                    "series": "300"
+                }
+            ],
+            "mainSector": {
+                "id": "Oq4A79YZZ8E"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "SImQCbjEbXz",
+            "name": "de-B081204",
+            "code": "B081204",
+            "externalsDescription": "",
+            "description": "de-description-B081204",
+            "sectorsInfo": [
+                {
+                    "id": "O2wdK9G0m9f",
+                    "series": "812"
+                }
+            ],
+            "mainSector": {
+                "id": "O2wdK9G0m9f"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "benefit",
+            "pairedDataElements": [
+                {
+                    "id": "Gg4qCBvZ99L",
+                    "code": "P081304",
+                    "name": "pde-P081304"
                 }
             ],
             "countingMethod": "",
@@ -9138,552 +9728,6 @@
             "selectable": true
         },
         {
-            "id": "qCc9Mog86QE",
-            "name": "de-P080203",
-            "code": "P080203",
-            "externalsDescription": "",
-            "description": "de-description-P080203",
-            "sectorsInfo": [
-                {
-                    "id": "O2wdK9G0m9f",
-                    "series": "802"
-                }
-            ],
-            "mainSector": {
-                "id": "O2wdK9G0m9f"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "eCiNhTEEwP2",
-            "name": "de-P080800",
-            "code": "P080800",
-            "externalsDescription": "",
-            "description": "de-description-P080800",
-            "sectorsInfo": [
-                {
-                    "id": "O2wdK9G0m9f",
-                    "series": "808"
-                }
-            ],
-            "mainSector": {
-                "id": "O2wdK9G0m9f"
-            },
-            "indicatorType": "global",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "mgSMcRjQY7P",
-            "name": "de-P080600",
-            "code": "P080600",
-            "externalsDescription": "",
-            "description": "de-description-P080600",
-            "sectorsInfo": [
-                {
-                    "id": "O2wdK9G0m9f",
-                    "series": "806"
-                }
-            ],
-            "mainSector": {
-                "id": "O2wdK9G0m9f"
-            },
-            "indicatorType": "global",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "miYneg7nVZR",
-            "name": "de-B030001",
-            "code": "B030001",
-            "externalsDescription": "",
-            "description": "de-description-B030001",
-            "sectorsInfo": [
-                {
-                    "id": "O2wdK9G0m9f",
-                    "series": "800"
-                },
-                {
-                    "id": "Oq4A79YZZ8E",
-                    "series": "300"
-                }
-            ],
-            "mainSector": {
-                "id": "Oq4A79YZZ8E"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "benefit",
-            "pairedDataElements": [
-                {
-                    "id": "awgF2cmvQrn",
-                    "code": "P030002",
-                    "name": "pde-P030002"
-                }
-            ],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "bjDvmb4bfuf",
-                "displayName": "None"
-            },
-            "selectable": true
-        },
-        {
-            "id": "qYMiVPnxFpT",
-            "name": "de-P030901",
-            "code": "P030901",
-            "externalsDescription": "",
-            "description": "de-description-P030901",
-            "sectorsInfo": [
-                {
-                    "id": "O2wdK9G0m9f",
-                    "series": "800"
-                },
-                {
-                    "id": "Oq4A79YZZ8E",
-                    "series": "309"
-                }
-            ],
-            "mainSector": {
-                "id": "Oq4A79YZZ8E"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "mm8STQA7P0V",
-            "name": "de-P070400",
-            "code": "P070400",
-            "externalsDescription": "",
-            "description": "de-description-P070400",
-            "sectorsInfo": [
-                {
-                    "id": "O2wdK9G0m9f",
-                    "series": "800"
-                },
-                {
-                    "id": "i8qug2Himby",
-                    "series": "704"
-                }
-            ],
-            "mainSector": {
-                "id": "i8qug2Himby"
-            },
-            "indicatorType": "global",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "KKmUWsn19fq",
-            "name": "de-P081300",
-            "code": "P081300",
-            "externalsDescription": "",
-            "description": "de-description-P081300",
-            "sectorsInfo": [
-                {
-                    "id": "O2wdK9G0m9f",
-                    "series": "813"
-                }
-            ],
-            "mainSector": {
-                "id": "O2wdK9G0m9f"
-            },
-            "indicatorType": "global",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "muknsuxQ5ch",
-            "name": "de-B081201",
-            "code": "B081201",
-            "externalsDescription": "",
-            "description": "de-description-B081201",
-            "sectorsInfo": [
-                {
-                    "id": "O2wdK9G0m9f",
-                    "series": "812"
-                }
-            ],
-            "mainSector": {
-                "id": "O2wdK9G0m9f"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "benefit",
-            "pairedDataElements": [
-                {
-                    "id": "eSqIjaS1r2w",
-                    "code": "P081301",
-                    "name": "pde-P081301"
-                }
-            ],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "bjDvmb4bfuf",
-                "displayName": "None"
-            },
-            "selectable": true
-        },
-        {
-            "id": "CQK2WzuEktG",
-            "name": "de-B080102",
-            "code": "B080102",
-            "externalsDescription": "",
-            "description": "de-description-B080102",
-            "sectorsInfo": [
-                {
-                    "id": "O2wdK9G0m9f",
-                    "series": "801"
-                }
-            ],
-            "mainSector": {
-                "id": "O2wdK9G0m9f"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "benefit",
-            "pairedDataElements": [
-                {
-                    "id": "qsyWwrmt33M",
-                    "code": "P080202",
-                    "name": "pde-P080202"
-                }
-            ],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "bjDvmb4bfuf",
-                "displayName": "None"
-            },
-            "selectable": true
-        },
-        {
-            "id": "CE9te39HtIt",
-            "name": "de-B081203",
-            "code": "B081203",
-            "externalsDescription": "",
-            "description": "de-description-B081203",
-            "sectorsInfo": [
-                {
-                    "id": "O2wdK9G0m9f",
-                    "series": "812"
-                }
-            ],
-            "mainSector": {
-                "id": "O2wdK9G0m9f"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "benefit",
-            "pairedDataElements": [
-                {
-                    "id": "iAQ5SzrWRoj",
-                    "code": "P081303",
-                    "name": "pde-P081303"
-                }
-            ],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "bjDvmb4bfuf",
-                "displayName": "None"
-            },
-            "selectable": true
-        },
-        {
-            "id": "Okq8Qfhx8Yn",
-            "name": "de-P081402",
-            "code": "P081402",
-            "externalsDescription": "",
-            "description": "de-description-P081402",
-            "sectorsInfo": [
-                {
-                    "id": "O2wdK9G0m9f",
-                    "series": "814"
-                }
-            ],
-            "mainSector": {
-                "id": "O2wdK9G0m9f"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "OI2puJwy7Q6",
-            "name": "de-P081100",
-            "code": "P081100",
-            "externalsDescription": "OFDA: Number of HHs having received shelter assistance",
-            "description": "de-description-P081100",
-            "sectorsInfo": [
-                {
-                    "id": "O2wdK9G0m9f",
-                    "series": "811"
-                }
-            ],
-            "mainSector": {
-                "id": "O2wdK9G0m9f"
-            },
-            "indicatorType": "global",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": ["OFDA"],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "OwUrgV6dRRD",
-            "name": "de-P080400",
-            "code": "P080400",
-            "externalsDescription": "",
-            "description": "de-description-P080400",
-            "sectorsInfo": [
-                {
-                    "id": "O2wdK9G0m9f",
-                    "series": "804"
-                }
-            ],
-            "mainSector": {
-                "id": "O2wdK9G0m9f"
-            },
-            "indicatorType": "global",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "m6QynUevAqo",
-            "name": "de-B081205",
-            "code": "B081205",
-            "externalsDescription": "",
-            "description": "de-description-B081205",
-            "sectorsInfo": [
-                {
-                    "id": "O2wdK9G0m9f",
-                    "series": "812"
-                }
-            ],
-            "mainSector": {
-                "id": "O2wdK9G0m9f"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "benefit",
-            "pairedDataElements": [
-                {
-                    "id": "OOCOr95zk1q",
-                    "code": "P081305",
-                    "name": "pde-P081305"
-                }
-            ],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "bjDvmb4bfuf",
-                "displayName": "None"
-            },
-            "selectable": true
-        },
-        {
-            "id": "KAqED5puVJR",
-            "name": "de-P080200",
-            "code": "P080200",
-            "externalsDescription": "",
-            "description": "de-description-P080200",
-            "sectorsInfo": [
-                {
-                    "id": "O2wdK9G0m9f",
-                    "series": "802"
-                }
-            ],
-            "mainSector": {
-                "id": "O2wdK9G0m9f"
-            },
-            "indicatorType": "global",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "eSqIjaS1r2w",
-            "name": "de-P081301",
-            "code": "P081301",
-            "externalsDescription": "",
-            "description": "de-description-P081301",
-            "sectorsInfo": [
-                {
-                    "id": "O2wdK9G0m9f",
-                    "series": "813"
-                }
-            ],
-            "mainSector": {
-                "id": "O2wdK9G0m9f"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "iAQ5SzrWRoj",
-            "name": "de-P081303",
-            "code": "P081303",
-            "externalsDescription": "",
-            "description": "de-description-P081303",
-            "sectorsInfo": [
-                {
-                    "id": "O2wdK9G0m9f",
-                    "series": "813"
-                }
-            ],
-            "mainSector": {
-                "id": "O2wdK9G0m9f"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "awgF2cmvQrn",
-            "name": "de-P030002",
-            "code": "P030002",
-            "externalsDescription": "",
-            "description": "de-description-P030002",
-            "sectorsInfo": [
-                {
-                    "id": "O2wdK9G0m9f",
-                    "series": "800"
-                },
-                {
-                    "id": "Oq4A79YZZ8E",
-                    "series": "300"
-                }
-            ],
-            "mainSector": {
-                "id": "Oq4A79YZZ8E"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "SImQCbjEbXz",
-            "name": "de-B081204",
-            "code": "B081204",
-            "externalsDescription": "",
-            "description": "de-description-B081204",
-            "sectorsInfo": [
-                {
-                    "id": "O2wdK9G0m9f",
-                    "series": "812"
-                }
-            ],
-            "mainSector": {
-                "id": "O2wdK9G0m9f"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "benefit",
-            "pairedDataElements": [
-                {
-                    "id": "Gg4qCBvZ99L",
-                    "code": "P081304",
-                    "name": "pde-P081304"
-                }
-            ],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "bjDvmb4bfuf",
-                "displayName": "None"
-            },
-            "selectable": true
-        },
-        {
             "id": "WwuQyH1Y38R",
             "name": "de-B081000",
             "code": "B081000",
@@ -9712,6 +9756,58 @@
             "categoryCombo": {
                 "id": "bjDvmb4bfuf",
                 "displayName": "None"
+            },
+            "selectable": true
+        },
+        {
+            "id": "qCc9Mog86QE",
+            "name": "de-P080203",
+            "code": "P080203",
+            "externalsDescription": "",
+            "description": "de-description-P080203",
+            "sectorsInfo": [
+                {
+                    "id": "O2wdK9G0m9f",
+                    "series": "802"
+                }
+            ],
+            "mainSector": {
+                "id": "O2wdK9G0m9f"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "OYkHOXijR2y",
+            "name": "de-P030602",
+            "code": "P030602",
+            "externalsDescription": "",
+            "description": "de-description-P030602",
+            "sectorsInfo": [
+                {
+                    "id": "Oq4A79YZZ8E",
+                    "series": "306"
+                }
+            ],
+            "mainSector": {
+                "id": "Oq4A79YZZ8E"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
             },
             "selectable": true
         },
@@ -9748,32 +9844,6 @@
             "selectable": true
         },
         {
-            "id": "OYkHOXijR2y",
-            "name": "de-P030602",
-            "code": "P030602",
-            "externalsDescription": "",
-            "description": "de-description-P030602",
-            "sectorsInfo": [
-                {
-                    "id": "Oq4A79YZZ8E",
-                    "series": "306"
-                }
-            ],
-            "mainSector": {
-                "id": "Oq4A79YZZ8E"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
             "id": "qkamQF5GoMT",
             "name": "de-P030705",
             "code": "P030705",
@@ -9794,7 +9864,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -9832,6 +9902,32 @@
             "selectable": true
         },
         {
+            "id": "meUNtJr7X5M",
+            "name": "de-P030702",
+            "code": "P030702",
+            "externalsDescription": "",
+            "description": "de-description-P030702",
+            "sectorsInfo": [
+                {
+                    "id": "Oq4A79YZZ8E",
+                    "series": "307"
+                }
+            ],
+            "mainSector": {
+                "id": "Oq4A79YZZ8E"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
             "id": "Ws48eBlsPVy",
             "name": "de-B030304",
             "code": "B030304",
@@ -9864,32 +9960,6 @@
             "selectable": true
         },
         {
-            "id": "meUNtJr7X5M",
-            "name": "de-P030702",
-            "code": "P030702",
-            "externalsDescription": "",
-            "description": "de-description-P030702",
-            "sectorsInfo": [
-                {
-                    "id": "Oq4A79YZZ8E",
-                    "series": "307"
-                }
-            ],
-            "mainSector": {
-                "id": "Oq4A79YZZ8E"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
             "id": "SuayUhAd7I9",
             "name": "de-P030404",
             "code": "P030404",
@@ -9910,7 +9980,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -9968,7 +10038,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -9994,7 +10064,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -10052,7 +10122,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -10110,7 +10180,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -10136,7 +10206,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -10162,7 +10232,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -10232,32 +10302,6 @@
             "selectable": true
         },
         {
-            "id": "GeIvUs41E1U",
-            "name": "de-P030201",
-            "code": "P030201",
-            "externalsDescription": "",
-            "description": "de-description-P030201",
-            "sectorsInfo": [
-                {
-                    "id": "Oq4A79YZZ8E",
-                    "series": "302"
-                }
-            ],
-            "mainSector": {
-                "id": "Oq4A79YZZ8E"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
             "id": "uyMhgwLwrzi",
             "name": "de-B030005",
             "code": "B030005",
@@ -10284,6 +10328,32 @@
             "selectable": true
         },
         {
+            "id": "GeIvUs41E1U",
+            "name": "de-P030201",
+            "code": "P030201",
+            "externalsDescription": "",
+            "description": "de-description-P030201",
+            "sectorsInfo": [
+                {
+                    "id": "Oq4A79YZZ8E",
+                    "series": "302"
+                }
+            ],
+            "mainSector": {
+                "id": "Oq4A79YZZ8E"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
             "id": "SiCifbteVub",
             "name": "de-P030205",
             "code": "P030205",
@@ -10304,7 +10374,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -10330,7 +10400,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -10356,7 +10426,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -10382,7 +10452,33 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "Ce4u0MTUype",
+            "name": "de-P030204",
+            "code": "P030204",
+            "externalsDescription": "",
+            "description": "de-description-P030204",
+            "sectorsInfo": [
+                {
+                    "id": "Oq4A79YZZ8E",
+                    "series": "302"
+                }
+            ],
+            "mainSector": {
+                "id": "Oq4A79YZZ8E"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -10416,32 +10512,6 @@
             "categoryCombo": {
                 "id": "bjDvmb4bfuf",
                 "displayName": "None"
-            },
-            "selectable": true
-        },
-        {
-            "id": "Ce4u0MTUype",
-            "name": "de-P030204",
-            "code": "P030204",
-            "externalsDescription": "",
-            "description": "de-description-P030204",
-            "sectorsInfo": [
-                {
-                    "id": "Oq4A79YZZ8E",
-                    "series": "302"
-                }
-            ],
-            "mainSector": {
-                "id": "Oq4A79YZZ8E"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
             },
             "selectable": true
         },
@@ -10498,7 +10568,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -10556,7 +10626,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -10646,7 +10716,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -10704,7 +10774,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -10730,7 +10800,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -10756,7 +10826,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -10782,7 +10852,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -10808,7 +10878,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -10834,7 +10904,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -11040,7 +11110,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -11066,7 +11136,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -11104,6 +11174,32 @@
             "selectable": true
         },
         {
+            "id": "qgqARJdCR8V",
+            "name": "de-P030010",
+            "code": "P030010",
+            "externalsDescription": "",
+            "description": "de-description-P030010",
+            "sectorsInfo": [
+                {
+                    "id": "Oq4A79YZZ8E",
+                    "series": "300"
+                }
+            ],
+            "mainSector": {
+                "id": "Oq4A79YZZ8E"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
             "id": "ecQncxEhoEE",
             "name": "de-B030101",
             "code": "B030101",
@@ -11132,32 +11228,6 @@
             "categoryCombo": {
                 "id": "bjDvmb4bfuf",
                 "displayName": "None"
-            },
-            "selectable": true
-        },
-        {
-            "id": "qgqARJdCR8V",
-            "name": "de-P030010",
-            "code": "P030010",
-            "externalsDescription": "",
-            "description": "de-description-P030010",
-            "sectorsInfo": [
-                {
-                    "id": "Oq4A79YZZ8E",
-                    "series": "300"
-                }
-            ],
-            "mainSector": {
-                "id": "Oq4A79YZZ8E"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
             },
             "selectable": true
         },
@@ -11194,32 +11264,6 @@
             "selectable": true
         },
         {
-            "id": "mM6TxfM7fqL",
-            "name": "de-P030206",
-            "code": "P030206",
-            "externalsDescription": "",
-            "description": "de-description-P030206",
-            "sectorsInfo": [
-                {
-                    "id": "Oq4A79YZZ8E",
-                    "series": "302"
-                }
-            ],
-            "mainSector": {
-                "id": "Oq4A79YZZ8E"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
             "id": "SM6Sz5h0fsL",
             "name": "de-B030301",
             "code": "B030301",
@@ -11252,6 +11296,32 @@
             "selectable": true
         },
         {
+            "id": "mM6TxfM7fqL",
+            "name": "de-P030206",
+            "code": "P030206",
+            "externalsDescription": "",
+            "description": "de-description-P030206",
+            "sectorsInfo": [
+                {
+                    "id": "Oq4A79YZZ8E",
+                    "series": "302"
+                }
+            ],
+            "mainSector": {
+                "id": "Oq4A79YZZ8E"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
             "id": "uE6ZPpbPz66",
             "name": "de-P030008",
             "code": "P030008",
@@ -11272,7 +11342,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -11298,7 +11368,7 @@
             "countingMethod": "",
             "externals": ["OFDA"],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -11446,7 +11516,33 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "GeGEm2k6WKy",
+            "name": "de-P070200",
+            "code": "P070200",
+            "externalsDescription": "",
+            "description": "de-description-P070200",
+            "sectorsInfo": [
+                {
+                    "id": "i8qug2Himby",
+                    "series": "702"
+                }
+            ],
+            "mainSector": {
+                "id": "i8qug2Himby"
+            },
+            "indicatorType": "global",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -11484,32 +11580,6 @@
             "selectable": true
         },
         {
-            "id": "GeGEm2k6WKy",
-            "name": "de-P070200",
-            "code": "P070200",
-            "externalsDescription": "",
-            "description": "de-description-P070200",
-            "sectorsInfo": [
-                {
-                    "id": "i8qug2Himby",
-                    "series": "702"
-                }
-            ],
-            "mainSector": {
-                "id": "i8qug2Himby"
-            },
-            "indicatorType": "global",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
             "id": "GsKksqhBDzS",
             "name": "de-P070102",
             "code": "P070102",
@@ -11530,7 +11600,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -11588,7 +11658,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -11614,7 +11684,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -11640,7 +11710,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -11666,7 +11736,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -11692,7 +11762,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -11718,7 +11788,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -11756,32 +11826,6 @@
             "selectable": true
         },
         {
-            "id": "Cg4c5HRdyJt",
-            "name": "de-P070201",
-            "code": "P070201",
-            "externalsDescription": "",
-            "description": "de-description-P070201",
-            "sectorsInfo": [
-                {
-                    "id": "i8qug2Himby",
-                    "series": "702"
-                }
-            ],
-            "mainSector": {
-                "id": "i8qug2Himby"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
             "id": "WUMjtbgofs2",
             "name": "de-B070700",
             "code": "B070700",
@@ -11814,6 +11858,32 @@
             "selectable": true
         },
         {
+            "id": "Cg4c5HRdyJt",
+            "name": "de-P070201",
+            "code": "P070201",
+            "externalsDescription": "",
+            "description": "de-description-P070201",
+            "sectorsInfo": [
+                {
+                    "id": "i8qug2Himby",
+                    "series": "702"
+                }
+            ],
+            "mainSector": {
+                "id": "i8qug2Himby"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
             "id": "S20aprHSmoY",
             "name": "de-P070001",
             "code": "P070001",
@@ -11834,7 +11904,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -11864,7 +11934,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -11916,7 +11986,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -11942,7 +12012,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -11968,7 +12038,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -11994,7 +12064,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -12020,7 +12090,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -12046,7 +12116,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -12072,7 +12142,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -12098,123 +12168,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "WmauKiAiueX",
-            "name": "de-B120104",
-            "code": "B120104",
-            "externalsDescription": "",
-            "description": "de-description-B120104",
-            "sectorsInfo": [
-                {
-                    "id": "WuI0CSeCdn7",
-                    "series": "1201"
-                }
-            ],
-            "mainSector": {
-                "id": "WuI0CSeCdn7"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "benefit",
-            "pairedDataElements": [
-                {
-                    "id": "eYIJJrOJ0JT",
-                    "code": "P120204",
-                    "name": "pde-P120204"
-                }
-            ],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "bjDvmb4bfuf",
-                "displayName": "None"
-            },
-            "selectable": true
-        },
-        {
-            "id": "eYMalffxy0L",
-            "name": "de-P120201",
-            "code": "P120201",
-            "externalsDescription": "",
-            "description": "de-description-P120201",
-            "sectorsInfo": [
-                {
-                    "id": "WuI0CSeCdn7",
-                    "series": "1202"
-                }
-            ],
-            "mainSector": {
-                "id": "WuI0CSeCdn7"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "awsNtaiPxBR",
-            "name": "de-B120100",
-            "code": "B120100",
-            "externalsDescription": "",
-            "description": "de-description-B120100",
-            "sectorsInfo": [
-                {
-                    "id": "WuI0CSeCdn7",
-                    "series": "1201"
-                }
-            ],
-            "mainSector": {
-                "id": "WuI0CSeCdn7"
-            },
-            "indicatorType": "global",
-            "peopleOrBenefit": "benefit",
-            "pairedDataElements": [
-                {
-                    "id": "em64U7iG9nf",
-                    "code": "P120200",
-                    "name": "pde-P120200"
-                }
-            ],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "bjDvmb4bfuf",
-                "displayName": "None"
-            },
-            "selectable": true
-        },
-        {
-            "id": "ysU7uKQJf1T",
-            "name": "de-P120202",
-            "code": "P120202",
-            "externalsDescription": "",
-            "description": "de-description-P120202",
-            "sectorsInfo": [
-                {
-                    "id": "WuI0CSeCdn7",
-                    "series": "1202"
-                }
-            ],
-            "mainSector": {
-                "id": "WuI0CSeCdn7"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -12272,7 +12226,65 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "WmauKiAiueX",
+            "name": "de-B120104",
+            "code": "B120104",
+            "externalsDescription": "",
+            "description": "de-description-B120104",
+            "sectorsInfo": [
+                {
+                    "id": "WuI0CSeCdn7",
+                    "series": "1201"
+                }
+            ],
+            "mainSector": {
+                "id": "WuI0CSeCdn7"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "benefit",
+            "pairedDataElements": [
+                {
+                    "id": "eYIJJrOJ0JT",
+                    "code": "P120204",
+                    "name": "pde-P120204"
+                }
+            ],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "bjDvmb4bfuf",
+                "displayName": "None"
+            },
+            "selectable": true
+        },
+        {
+            "id": "eYMalffxy0L",
+            "name": "de-P120201",
+            "code": "P120201",
+            "externalsDescription": "",
+            "description": "de-description-P120201",
+            "sectorsInfo": [
+                {
+                    "id": "WuI0CSeCdn7",
+                    "series": "1202"
+                }
+            ],
+            "mainSector": {
+                "id": "WuI0CSeCdn7"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -12306,6 +12318,64 @@
             "categoryCombo": {
                 "id": "bjDvmb4bfuf",
                 "displayName": "None"
+            },
+            "selectable": true
+        },
+        {
+            "id": "awsNtaiPxBR",
+            "name": "de-B120100",
+            "code": "B120100",
+            "externalsDescription": "",
+            "description": "de-description-B120100",
+            "sectorsInfo": [
+                {
+                    "id": "WuI0CSeCdn7",
+                    "series": "1201"
+                }
+            ],
+            "mainSector": {
+                "id": "WuI0CSeCdn7"
+            },
+            "indicatorType": "global",
+            "peopleOrBenefit": "benefit",
+            "pairedDataElements": [
+                {
+                    "id": "em64U7iG9nf",
+                    "code": "P120200",
+                    "name": "pde-P120200"
+                }
+            ],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "bjDvmb4bfuf",
+                "displayName": "None"
+            },
+            "selectable": true
+        },
+        {
+            "id": "ysU7uKQJf1T",
+            "name": "de-P120202",
+            "code": "P120202",
+            "externalsDescription": "",
+            "description": "de-description-P120202",
+            "sectorsInfo": [
+                {
+                    "id": "WuI0CSeCdn7",
+                    "series": "1202"
+                }
+            ],
+            "mainSector": {
+                "id": "WuI0CSeCdn7"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
             },
             "selectable": true
         },
@@ -12362,7 +12432,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -12388,33 +12458,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "KueoAZr2xIV",
-            "name": "de-P100800",
-            "code": "P100800",
-            "externalsDescription": "",
-            "description": "de-description-P100800",
-            "sectorsInfo": [
-                {
-                    "id": "auULQasRbJL",
-                    "series": "1008"
-                }
-            ],
-            "mainSector": {
-                "id": "auULQasRbJL"
-            },
-            "indicatorType": "global",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -12440,7 +12484,33 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "KueoAZr2xIV",
+            "name": "de-P100800",
+            "code": "P100800",
+            "externalsDescription": "",
+            "description": "de-description-P100800",
+            "sectorsInfo": [
+                {
+                    "id": "auULQasRbJL",
+                    "series": "1008"
+                }
+            ],
+            "mainSector": {
+                "id": "auULQasRbJL"
+            },
+            "indicatorType": "global",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -12492,7 +12562,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -12550,7 +12620,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -12576,7 +12646,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -12602,7 +12672,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -12628,7 +12698,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -12654,7 +12724,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -12680,7 +12750,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -12706,7 +12776,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -12732,7 +12802,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -12758,7 +12828,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -12784,7 +12854,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -12810,34 +12880,8 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "ywQfPB6FJCu",
-            "name": "de-B100001",
-            "code": "B100001",
-            "externalsDescription": "",
-            "description": "de-description-B100001",
-            "sectorsInfo": [
-                {
-                    "id": "auULQasRbJL",
-                    "series": "1000"
-                }
-            ],
-            "mainSector": {
-                "id": "auULQasRbJL"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "benefit",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "bjDvmb4bfuf",
-                "displayName": "None"
             },
             "selectable": true
         },
@@ -12874,6 +12918,32 @@
             "selectable": true
         },
         {
+            "id": "ywQfPB6FJCu",
+            "name": "de-B100001",
+            "code": "B100001",
+            "externalsDescription": "",
+            "description": "de-description-B100001",
+            "sectorsInfo": [
+                {
+                    "id": "auULQasRbJL",
+                    "series": "1000"
+                }
+            ],
+            "mainSector": {
+                "id": "auULQasRbJL"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "benefit",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "bjDvmb4bfuf",
+                "displayName": "None"
+            },
+            "selectable": true
+        },
+        {
             "id": "yqmyP1vNJk0",
             "name": "de-P100303",
             "code": "P100303",
@@ -12894,7 +12964,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -12920,33 +12990,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "CQEv5mMFQwk",
-            "name": "de-P100104",
-            "code": "P100104",
-            "externalsDescription": "",
-            "description": "de-description-P100104",
-            "sectorsInfo": [
-                {
-                    "id": "auULQasRbJL",
-                    "series": "1001"
-                }
-            ],
-            "mainSector": {
-                "id": "auULQasRbJL"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -12972,7 +13016,33 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "CQEv5mMFQwk",
+            "name": "de-P100104",
+            "code": "P100104",
+            "externalsDescription": "",
+            "description": "de-description-P100104",
+            "sectorsInfo": [
+                {
+                    "id": "auULQasRbJL",
+                    "series": "1001"
+                }
+            ],
+            "mainSector": {
+                "id": "auULQasRbJL"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -12998,7 +13068,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -13024,7 +13094,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -13050,7 +13120,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -13076,33 +13146,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "qcwhkIgx56S",
-            "name": "de-P100101",
-            "code": "P100101",
-            "externalsDescription": "",
-            "description": "de-description-P100101",
-            "sectorsInfo": [
-                {
-                    "id": "auULQasRbJL",
-                    "series": "1001"
-                }
-            ],
-            "mainSector": {
-                "id": "auULQasRbJL"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -13128,7 +13172,33 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
+            },
+            "selectable": true
+        },
+        {
+            "id": "qcwhkIgx56S",
+            "name": "de-P100101",
+            "code": "P100101",
+            "externalsDescription": "",
+            "description": "de-description-P100101",
+            "sectorsInfo": [
+                {
+                    "id": "auULQasRbJL",
+                    "series": "1001"
+                }
+            ],
+            "mainSector": {
+                "id": "auULQasRbJL"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -13186,7 +13256,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -13212,7 +13282,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -13238,7 +13308,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -13264,7 +13334,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -13316,7 +13386,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -13374,7 +13444,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -13458,7 +13528,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -13484,7 +13554,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -13510,7 +13580,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -13536,7 +13606,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -13562,7 +13632,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -13620,7 +13690,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -13678,7 +13748,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -13704,7 +13774,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -13762,7 +13832,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -13788,7 +13858,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -13840,7 +13910,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -13930,7 +14000,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -13956,7 +14026,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -13982,7 +14052,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -14008,7 +14078,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -14034,7 +14104,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -14092,7 +14162,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -14118,7 +14188,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -14170,40 +14240,8 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "SGiIDNhFovM",
-            "name": "de-B130600",
-            "code": "B130600",
-            "externalsDescription": "",
-            "description": "de-description-B130600",
-            "sectorsInfo": [
-                {
-                    "id": "yc6nqm2e2wG",
-                    "series": "1306"
-                }
-            ],
-            "mainSector": {
-                "id": "yc6nqm2e2wG"
-            },
-            "indicatorType": "global",
-            "peopleOrBenefit": "benefit",
-            "pairedDataElements": [
-                {
-                    "id": "Omobz0poEAJ",
-                    "code": "P130700",
-                    "name": "pde-P130700"
-                }
-            ],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "bjDvmb4bfuf",
-                "displayName": "None"
             },
             "selectable": true
         },
@@ -14240,6 +14278,38 @@
             "selectable": true
         },
         {
+            "id": "SGiIDNhFovM",
+            "name": "de-B130600",
+            "code": "B130600",
+            "externalsDescription": "",
+            "description": "de-description-B130600",
+            "sectorsInfo": [
+                {
+                    "id": "yc6nqm2e2wG",
+                    "series": "1306"
+                }
+            ],
+            "mainSector": {
+                "id": "yc6nqm2e2wG"
+            },
+            "indicatorType": "global",
+            "peopleOrBenefit": "benefit",
+            "pairedDataElements": [
+                {
+                    "id": "Omobz0poEAJ",
+                    "code": "P130700",
+                    "name": "pde-P130700"
+                }
+            ],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "bjDvmb4bfuf",
+                "displayName": "None"
+            },
+            "selectable": true
+        },
+        {
             "id": "qM69VnOH5U7",
             "name": "de-P132000",
             "code": "P132000",
@@ -14260,7 +14330,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -14286,7 +14356,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -14312,7 +14382,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -14338,7 +14408,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -14448,7 +14518,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -14474,7 +14544,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -14500,7 +14570,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -14552,7 +14622,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -14578,7 +14648,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -14604,7 +14674,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -14656,33 +14726,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
-                "displayName": "New-Returning/Gender"
-            },
-            "selectable": true
-        },
-        {
-            "id": "qCaKOh97pu5",
-            "name": "de-P130003",
-            "code": "P130003",
-            "externalsDescription": "",
-            "description": "de-description-P130003",
-            "sectorsInfo": [
-                {
-                    "id": "yc6nqm2e2wG",
-                    "series": "1300"
-                }
-            ],
-            "mainSector": {
-                "id": "yc6nqm2e2wG"
-            },
-            "indicatorType": "sub",
-            "peopleOrBenefit": "people",
-            "pairedDataElements": [],
-            "countingMethod": "",
-            "externals": [],
-            "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -14716,6 +14760,32 @@
             "categoryCombo": {
                 "id": "bjDvmb4bfuf",
                 "displayName": "None"
+            },
+            "selectable": true
+        },
+        {
+            "id": "qCaKOh97pu5",
+            "name": "de-P130003",
+            "code": "P130003",
+            "externalsDescription": "",
+            "description": "de-description-P130003",
+            "sectorsInfo": [
+                {
+                    "id": "yc6nqm2e2wG",
+                    "series": "1300"
+                }
+            ],
+            "mainSector": {
+                "id": "yc6nqm2e2wG"
+            },
+            "indicatorType": "sub",
+            "peopleOrBenefit": "people",
+            "pairedDataElements": [],
+            "countingMethod": "",
+            "externals": [],
+            "categoryCombo": {
+                "id": "S0GIshZAqgK",
+                "displayName": "New-Returning/Gender"
             },
             "selectable": true
         },
@@ -14772,7 +14842,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -14830,7 +14900,7 @@
             "countingMethod": "",
             "externals": [],
             "categoryCombo": {
-                "id": "GKWiemQPU5U",
+                "id": "S0GIshZAqgK",
                 "displayName": "New-Returning/Gender"
             },
             "selectable": true
@@ -14902,10 +14972,19 @@
     ],
     "funders": [
         {
-            "id": "SeMUgKohfme",
+            "id": "aOYJkeWdv2t",
             "shortName": "IHQ",
-            "displayName": "funder-SeMUgKohfme",
-            "organisationUnits": []
+            "displayName": "funder-aOYJkeWdv2t",
+            "organisationUnits": [
+                {
+                    "level": 3,
+                    "id": "PDPLquFcojy"
+                },
+                {
+                    "level": 3,
+                    "id": "npvbamb9jSO"
+                }
+            ]
         },
         {
             "id": "OE0KdZRX2FC",
@@ -14926,7 +15005,7 @@
             "organisationUnits": [
                 {
                     "level": 3,
-                    "id": "umPLxxTujfr"
+                    "id": "npvbamb9jSO"
                 }
             ]
         },
@@ -14934,23 +15013,13 @@
             "id": "CeApFdQGS5x",
             "shortName": "AMREF",
             "displayName": "funder-CeApFdQGS5x",
-            "organisationUnits": [
-                {
-                    "level": 3,
-                    "id": "umPLxxTujfr"
-                }
-            ]
+            "organisationUnits": []
         },
         {
             "id": "qMyQJENdWHU",
             "shortName": "AED",
             "displayName": "funder-qMyQJENdWHU",
-            "organisationUnits": [
-                {
-                    "level": 3,
-                    "id": "HY4yXR2zM9n"
-                }
-            ]
+            "organisationUnits": []
         },
         {
             "id": "qkWv2nJuDZm",
@@ -14989,9 +15058,9 @@
             "organisationUnits": []
         },
         {
-            "id": "OKEZCrPzqph",
+            "id": "O0So8MfyNG3",
             "shortName": "AC",
-            "displayName": "funder-OKEZCrPzqph",
+            "displayName": "funder-O0So8MfyNG3",
             "organisationUnits": []
         },
         {
@@ -15181,9 +15250,9 @@
             "organisationUnits": []
         },
         {
-            "id": "GmWPE2eaHbJ",
+            "id": "OiqC6JAICpy",
             "shortName": "DFATD",
-            "displayName": "funder-GmWPE2eaHbJ",
+            "displayName": "funder-OiqC6JAICpy",
             "organisationUnits": []
         },
         {
@@ -15247,9 +15316,9 @@
             "organisationUnits": []
         },
         {
-            "id": "mYmSF3QXLoX",
+            "id": "qqaMHmNu9SR",
             "shortName": "EV",
-            "displayName": "funder-mYmSF3QXLoX",
+            "displayName": "funder-qqaMHmNu9SR",
             "organisationUnits": []
         },
         {
@@ -15325,9 +15394,9 @@
             "organisationUnits": []
         },
         {
-            "id": "WYAFZkSDigf",
+            "id": "KyYP6Rswepl",
             "shortName": "GAC",
-            "displayName": "funder-WYAFZkSDigf",
+            "displayName": "funder-KyYP6Rswepl",
             "organisationUnits": []
         },
         {
@@ -15427,9 +15496,9 @@
             "organisationUnits": []
         },
         {
-            "id": "yUCqjHAkYki",
+            "id": "uOE9XQ6HXxU",
             "shortName": "IHPF",
-            "displayName": "funder-yUCqjHAkYki",
+            "displayName": "funder-uOE9XQ6HXxU",
             "organisationUnits": []
         },
         {
@@ -15523,9 +15592,9 @@
             "organisationUnits": []
         },
         {
-            "id": "SAOiSpMAN3M",
+            "id": "my8GmeQ3eA4",
             "shortName": "MA",
-            "displayName": "funder-SAOiSpMAN3M",
+            "displayName": "funder-my8GmeQ3eA4",
             "organisationUnits": []
         },
         {
@@ -15541,9 +15610,9 @@
             "organisationUnits": []
         },
         {
-            "id": "uSaHNNmnzie",
+            "id": "uWa24mLh8Zd",
             "shortName": "MO",
-            "displayName": "funder-uSaHNNmnzie",
+            "displayName": "funder-uWa24mLh8Zd",
             "organisationUnits": []
         },
         {
@@ -15583,9 +15652,9 @@
             "organisationUnits": []
         },
         {
-            "id": "GkADjWIsyww",
+            "id": "i8QN1K1c6yb",
             "shortName": "NP",
-            "displayName": "funder-GkADjWIsyww",
+            "displayName": "funder-i8QN1K1c6yb",
             "organisationUnits": []
         },
         {
@@ -15661,9 +15730,9 @@
             "organisationUnits": []
         },
         {
-            "id": "OGktJOeZZ9B",
+            "id": "OGMF0vWKzZe",
             "shortName": "PAEGC",
-            "displayName": "funder-OGktJOeZZ9B",
+            "displayName": "funder-OGMF0vWKzZe",
             "organisationUnits": []
         },
         {
@@ -15883,9 +15952,9 @@
             "organisationUnits": []
         },
         {
-            "id": "SGKOtCbaSye",
+            "id": "aI2XL9DfbcJ",
             "shortName": "UNOESCO",
-            "displayName": "funder-SGKOtCbaSye",
+            "displayName": "funder-aI2XL9DfbcJ",
             "organisationUnits": []
         },
         {
@@ -15907,15 +15976,15 @@
             "organisationUnits": []
         },
         {
-            "id": "SWYryJ6NamX",
+            "id": "a0cf9CP4U4K",
             "shortName": "UNOCHA",
-            "displayName": "funder-SWYryJ6NamX",
+            "displayName": "funder-a0cf9CP4U4K",
             "organisationUnits": []
         },
         {
-            "id": "qmANxWw6XlU",
+            "id": "yKWWuyTbDUE",
             "shortName": "MONUC",
-            "displayName": "funder-qmANxWw6XlU",
+            "displayName": "funder-yKWWuyTbDUE",
             "organisationUnits": []
         },
         {
@@ -15925,9 +15994,9 @@
             "organisationUnits": []
         },
         {
-            "id": "ekAr5F6Nv6f",
+            "id": "q2cnDMrWCNf",
             "shortName": "UNVTFSCFS",
-            "displayName": "funder-ekAr5F6Nv6f",
+            "displayName": "funder-q2cnDMrWCNf",
             "organisationUnits": []
         },
         {
@@ -15997,9 +16066,9 @@
             "organisationUnits": []
         },
         {
-            "id": "q06zljX55bN",
+            "id": "yyAZvNgrdCP",
             "shortName": "WFP",
-            "displayName": "funder-q06zljX55bN",
+            "displayName": "funder-yyAZvNgrdCP",
             "organisationUnits": []
         },
         {
@@ -19665,14 +19734,6 @@
             "id": "aAMTlVPzw2C"
         },
         {
-            "code": "ACTUAL_TARGET_B030305",
-            "id": "WES2gTOS05G"
-        },
-        {
-            "code": "COST_BENEFIT_B030305",
-            "id": "COKEX5pyfZm"
-        },
-        {
             "code": "ACTUAL_TARGET_P060105",
             "id": "KkA3NMjeNGd"
         },
@@ -19863,10 +19924,6 @@
         {
             "code": "ACTUAL_TARGET_P030402",
             "id": "ysfsen6sUvA"
-        },
-        {
-            "code": "ACTUAL_TARGET_P030405",
-            "id": "SQ6xRgvh84P"
         },
         {
             "code": "ACTUAL_TARGET_P030210",
@@ -21003,7 +21060,7 @@
             "id": "OOi8Yw1TrmS"
         },
         "createdByApp": {
-            "code": "PM_CREATED_BY_PROJECT_MONITORING",
+            "code": "PM_CREATED_BY_DATA_MANAGEMENT",
             "id": "mgCKcJuP5n0"
         },
         "mainSector": {
@@ -21074,15 +21131,15 @@
         },
         "newRecurring": {
             "code": "NEW_RETURNING",
-            "id": "a0Cy1qwUuZv",
+            "id": "uSMHdwhxFSV",
             "categoryOptions": [
                 {
                     "code": "NEW",
-                    "id": "S2y8dcmR2kD"
+                    "id": "KiK0FMExoqh"
                 },
                 {
                     "code": "RETURNING",
-                    "id": "CyILz2yY8ey"
+                    "id": "a6AJLXQy8vO"
                 }
             ]
         }
@@ -21090,7 +21147,7 @@
     "categoryCombos": {
         "targetActual": {
             "code": "ACTUAL_TARGET",
-            "id": "pQjIEZS8Sx7",
+            "id": "qAgB0mD1wC6",
             "displayName": "Actual/Target",
             "categories": [
                 {
@@ -21099,7 +21156,7 @@
             ],
             "categoryOptionCombos": [
                 {
-                    "id": "H8Sj3601jDn",
+                    "id": "J5W5ysZYXJ0",
                     "displayName": "Target",
                     "categoryOptions": [
                         {
@@ -21109,7 +21166,7 @@
                     ]
                 },
                 {
-                    "id": "lbxlzyXK4zr",
+                    "id": "UXGKWg5JPWA",
                     "displayName": "Actual",
                     "categoryOptions": [
                         {
@@ -21131,7 +21188,7 @@
             ],
             "categoryOptionCombos": [
                 {
-                    "id": "sJpz2vAuxfb",
+                    "id": "LJ0asVZzMQA",
                     "displayName": "COVID-19",
                     "categoryOptions": [
                         {
@@ -21151,7 +21208,7 @@
                     "id": "ae61RHJtdOT"
                 },
                 {
-                    "id": "a0Cy1qwUuZv"
+                    "id": "uSMHdwhxFSV"
                 },
                 {
                     "id": "Kyg1O6YEGa9"
@@ -21159,7 +21216,25 @@
             ],
             "categoryOptionCombos": [
                 {
-                    "id": "Au7kJLKqCAY",
+                    "id": "aoRpDH3cNkD",
+                    "displayName": "COVID-19, New, Female",
+                    "categoryOptions": [
+                        {
+                            "id": "KiK0FMExoqh",
+                            "displayName": "New"
+                        },
+                        {
+                            "id": "CW0Ym5sg6rL",
+                            "displayName": "COVID-19"
+                        },
+                        {
+                            "id": "yW2hYVS3S4u",
+                            "displayName": "Female"
+                        }
+                    ]
+                },
+                {
+                    "id": "TK1REL6Fx4k",
                     "displayName": "COVID-19, Returning, Female",
                     "categoryOptions": [
                         {
@@ -21167,37 +21242,23 @@
                             "displayName": "COVID-19"
                         },
                         {
-                            "id": "CyILz2yY8ey",
+                            "id": "yW2hYVS3S4u",
+                            "displayName": "Female"
+                        },
+                        {
+                            "id": "a6AJLXQy8vO",
                             "displayName": "Returning"
-                        },
-                        {
-                            "id": "yW2hYVS3S4u",
-                            "displayName": "Female"
                         }
                     ]
                 },
                 {
-                    "id": "bOokLlHM9no",
-                    "displayName": "COVID-19, New, Female",
-                    "categoryOptions": [
-                        {
-                            "id": "CW0Ym5sg6rL",
-                            "displayName": "COVID-19"
-                        },
-                        {
-                            "id": "S2y8dcmR2kD",
-                            "displayName": "New"
-                        },
-                        {
-                            "id": "yW2hYVS3S4u",
-                            "displayName": "Female"
-                        }
-                    ]
-                },
-                {
-                    "id": "kx33GL2khoi",
+                    "id": "kYnK9rhdUYO",
                     "displayName": "COVID-19, New, Male",
                     "categoryOptions": [
+                        {
+                            "id": "KiK0FMExoqh",
+                            "displayName": "New"
+                        },
                         {
                             "id": "CW0Ym5sg6rL",
                             "displayName": "COVID-19"
@@ -21205,15 +21266,11 @@
                         {
                             "id": "qk2FihwV6IL",
                             "displayName": "Male"
-                        },
-                        {
-                            "id": "S2y8dcmR2kD",
-                            "displayName": "New"
                         }
                     ]
                 },
                 {
-                    "id": "i4nidjHBsme",
+                    "id": "xCnBGy67HEN",
                     "displayName": "COVID-19, Returning, Male",
                     "categoryOptions": [
                         {
@@ -21221,12 +21278,12 @@
                             "displayName": "COVID-19"
                         },
                         {
-                            "id": "CyILz2yY8ey",
-                            "displayName": "Returning"
-                        },
-                        {
                             "id": "qk2FihwV6IL",
                             "displayName": "Male"
+                        },
+                        {
+                            "id": "a6AJLXQy8vO",
+                            "displayName": "Returning"
                         }
                     ]
                 }
@@ -21256,11 +21313,11 @@
         },
         "genderNewRecurring": {
             "code": "NEW_RETURNING_GENDER",
-            "id": "GKWiemQPU5U",
+            "id": "S0GIshZAqgK",
             "displayName": "New-Returning/Gender",
             "categories": [
                 {
-                    "id": "a0Cy1qwUuZv"
+                    "id": "uSMHdwhxFSV"
                 },
                 {
                     "id": "Kyg1O6YEGa9"
@@ -21268,25 +21325,11 @@
             ],
             "categoryOptionCombos": [
                 {
-                    "id": "xgT2W9JaXTq",
-                    "displayName": "Female, Recurring",
+                    "id": "KB5Mfe7zpOw",
+                    "displayName": "New, Female",
                     "categoryOptions": [
                         {
-                            "id": "CyILz2yY8ey",
-                            "displayName": "Returning"
-                        },
-                        {
-                            "id": "yW2hYVS3S4u",
-                            "displayName": "Female"
-                        }
-                    ]
-                },
-                {
-                    "id": "UU2P0YSJM8A",
-                    "displayName": "Female, New",
-                    "categoryOptions": [
-                        {
-                            "id": "S2y8dcmR2kD",
+                            "id": "KiK0FMExoqh",
                             "displayName": "New"
                         },
                         {
@@ -21296,30 +21339,44 @@
                     ]
                 },
                 {
-                    "id": "nwv02VfyQuz",
-                    "displayName": "Male, New",
+                    "id": "sYO8lQMbA7f",
+                    "displayName": "Returning, Female",
                     "categoryOptions": [
                         {
-                            "id": "qk2FihwV6IL",
-                            "displayName": "Male"
+                            "id": "yW2hYVS3S4u",
+                            "displayName": "Female"
                         },
                         {
-                            "id": "S2y8dcmR2kD",
-                            "displayName": "New"
+                            "id": "a6AJLXQy8vO",
+                            "displayName": "Returning"
                         }
                     ]
                 },
                 {
-                    "id": "rgEN46cGauU",
-                    "displayName": "Male, Recurring",
+                    "id": "RZeJX0Tg9Tx",
+                    "displayName": "New, Male",
                     "categoryOptions": [
                         {
-                            "id": "CyILz2yY8ey",
-                            "displayName": "Returning"
+                            "id": "KiK0FMExoqh",
+                            "displayName": "New"
                         },
                         {
                             "id": "qk2FihwV6IL",
                             "displayName": "Male"
+                        }
+                    ]
+                },
+                {
+                    "id": "gRb1QRLyCUZ",
+                    "displayName": "Returning, Male",
+                    "categoryOptions": [
+                        {
+                            "id": "qk2FihwV6IL",
+                            "displayName": "Male"
+                        },
+                        {
+                            "id": "a6AJLXQy8vO",
+                            "displayName": "Returning"
                         }
                     ]
                 }
@@ -21329,7 +21386,7 @@
     "allCategoryCombos": [
         {
             "code": "ACTUAL_TARGET",
-            "id": "pQjIEZS8Sx7",
+            "id": "qAgB0mD1wC6",
             "displayName": "Actual/Target",
             "categories": [
                 {
@@ -21338,7 +21395,7 @@
             ],
             "categoryOptionCombos": [
                 {
-                    "id": "H8Sj3601jDn",
+                    "id": "J5W5ysZYXJ0",
                     "displayName": "Target",
                     "categoryOptions": [
                         {
@@ -21348,7 +21405,7 @@
                     ]
                 },
                 {
-                    "id": "lbxlzyXK4zr",
+                    "id": "UXGKWg5JPWA",
                     "displayName": "Actual",
                     "categoryOptions": [
                         {
@@ -21370,7 +21427,7 @@
             ],
             "categoryOptionCombos": [
                 {
-                    "id": "sJpz2vAuxfb",
+                    "id": "LJ0asVZzMQA",
                     "displayName": "COVID-19",
                     "categoryOptions": [
                         {
@@ -21390,7 +21447,7 @@
                     "id": "ae61RHJtdOT"
                 },
                 {
-                    "id": "a0Cy1qwUuZv"
+                    "id": "uSMHdwhxFSV"
                 },
                 {
                     "id": "Kyg1O6YEGa9"
@@ -21398,7 +21455,25 @@
             ],
             "categoryOptionCombos": [
                 {
-                    "id": "Au7kJLKqCAY",
+                    "id": "aoRpDH3cNkD",
+                    "displayName": "COVID-19, New, Female",
+                    "categoryOptions": [
+                        {
+                            "id": "KiK0FMExoqh",
+                            "displayName": "New"
+                        },
+                        {
+                            "id": "CW0Ym5sg6rL",
+                            "displayName": "COVID-19"
+                        },
+                        {
+                            "id": "yW2hYVS3S4u",
+                            "displayName": "Female"
+                        }
+                    ]
+                },
+                {
+                    "id": "TK1REL6Fx4k",
                     "displayName": "COVID-19, Returning, Female",
                     "categoryOptions": [
                         {
@@ -21406,37 +21481,23 @@
                             "displayName": "COVID-19"
                         },
                         {
-                            "id": "CyILz2yY8ey",
+                            "id": "yW2hYVS3S4u",
+                            "displayName": "Female"
+                        },
+                        {
+                            "id": "a6AJLXQy8vO",
                             "displayName": "Returning"
-                        },
-                        {
-                            "id": "yW2hYVS3S4u",
-                            "displayName": "Female"
                         }
                     ]
                 },
                 {
-                    "id": "bOokLlHM9no",
-                    "displayName": "COVID-19, New, Female",
-                    "categoryOptions": [
-                        {
-                            "id": "CW0Ym5sg6rL",
-                            "displayName": "COVID-19"
-                        },
-                        {
-                            "id": "S2y8dcmR2kD",
-                            "displayName": "New"
-                        },
-                        {
-                            "id": "yW2hYVS3S4u",
-                            "displayName": "Female"
-                        }
-                    ]
-                },
-                {
-                    "id": "kx33GL2khoi",
+                    "id": "kYnK9rhdUYO",
                     "displayName": "COVID-19, New, Male",
                     "categoryOptions": [
+                        {
+                            "id": "KiK0FMExoqh",
+                            "displayName": "New"
+                        },
                         {
                             "id": "CW0Ym5sg6rL",
                             "displayName": "COVID-19"
@@ -21444,15 +21505,11 @@
                         {
                             "id": "qk2FihwV6IL",
                             "displayName": "Male"
-                        },
-                        {
-                            "id": "S2y8dcmR2kD",
-                            "displayName": "New"
                         }
                     ]
                 },
                 {
-                    "id": "i4nidjHBsme",
+                    "id": "xCnBGy67HEN",
                     "displayName": "COVID-19, Returning, Male",
                     "categoryOptions": [
                         {
@@ -21460,12 +21517,12 @@
                             "displayName": "COVID-19"
                         },
                         {
-                            "id": "CyILz2yY8ey",
-                            "displayName": "Returning"
-                        },
-                        {
                             "id": "qk2FihwV6IL",
                             "displayName": "Male"
+                        },
+                        {
+                            "id": "a6AJLXQy8vO",
+                            "displayName": "Returning"
                         }
                     ]
                 }
@@ -21495,11 +21552,11 @@
         },
         {
             "code": "NEW_RETURNING_GENDER",
-            "id": "GKWiemQPU5U",
+            "id": "S0GIshZAqgK",
             "displayName": "New-Returning/Gender",
             "categories": [
                 {
-                    "id": "a0Cy1qwUuZv"
+                    "id": "uSMHdwhxFSV"
                 },
                 {
                     "id": "Kyg1O6YEGa9"
@@ -21507,25 +21564,11 @@
             ],
             "categoryOptionCombos": [
                 {
-                    "id": "xgT2W9JaXTq",
-                    "displayName": "Female, Recurring",
+                    "id": "KB5Mfe7zpOw",
+                    "displayName": "New, Female",
                     "categoryOptions": [
                         {
-                            "id": "CyILz2yY8ey",
-                            "displayName": "Returning"
-                        },
-                        {
-                            "id": "yW2hYVS3S4u",
-                            "displayName": "Female"
-                        }
-                    ]
-                },
-                {
-                    "id": "UU2P0YSJM8A",
-                    "displayName": "Female, New",
-                    "categoryOptions": [
-                        {
-                            "id": "S2y8dcmR2kD",
+                            "id": "KiK0FMExoqh",
                             "displayName": "New"
                         },
                         {
@@ -21535,30 +21578,44 @@
                     ]
                 },
                 {
-                    "id": "nwv02VfyQuz",
-                    "displayName": "Male, New",
+                    "id": "sYO8lQMbA7f",
+                    "displayName": "Returning, Female",
                     "categoryOptions": [
                         {
-                            "id": "qk2FihwV6IL",
-                            "displayName": "Male"
+                            "id": "yW2hYVS3S4u",
+                            "displayName": "Female"
                         },
                         {
-                            "id": "S2y8dcmR2kD",
-                            "displayName": "New"
+                            "id": "a6AJLXQy8vO",
+                            "displayName": "Returning"
                         }
                     ]
                 },
                 {
-                    "id": "rgEN46cGauU",
-                    "displayName": "Male, Recurring",
+                    "id": "RZeJX0Tg9Tx",
+                    "displayName": "New, Male",
                     "categoryOptions": [
                         {
-                            "id": "CyILz2yY8ey",
-                            "displayName": "Returning"
+                            "id": "KiK0FMExoqh",
+                            "displayName": "New"
                         },
                         {
                             "id": "qk2FihwV6IL",
                             "displayName": "Male"
+                        }
+                    ]
+                },
+                {
+                    "id": "gRb1QRLyCUZ",
+                    "displayName": "Returning, Male",
+                    "categoryOptions": [
+                        {
+                            "id": "qk2FihwV6IL",
+                            "displayName": "Male"
+                        },
+                        {
+                            "id": "a6AJLXQy8vO",
+                            "displayName": "Returning"
                         }
                     ]
                 }
@@ -21571,7 +21628,7 @@
             "id": "eWeQoOlAcxV",
             "categoryOptionCombos": [
                 {
-                    "id": "lbxlzyXK4zr"
+                    "id": "UXGKWg5JPWA"
                 }
             ]
         },
@@ -21580,19 +21637,19 @@
             "id": "CW0Ym5sg6rL",
             "categoryOptionCombos": [
                 {
-                    "id": "Au7kJLKqCAY"
+                    "id": "LJ0asVZzMQA"
                 },
                 {
-                    "id": "bOokLlHM9no"
+                    "id": "aoRpDH3cNkD"
                 },
                 {
-                    "id": "kx33GL2khoi"
+                    "id": "TK1REL6Fx4k"
                 },
                 {
-                    "id": "sJpz2vAuxfb"
+                    "id": "kYnK9rhdUYO"
                 },
                 {
-                    "id": "i4nidjHBsme"
+                    "id": "xCnBGy67HEN"
                 }
             ]
         },
@@ -21601,16 +21658,16 @@
             "id": "yW2hYVS3S4u",
             "categoryOptionCombos": [
                 {
-                    "id": "xgT2W9JaXTq"
+                    "id": "aoRpDH3cNkD"
                 },
                 {
-                    "id": "UU2P0YSJM8A"
+                    "id": "TK1REL6Fx4k"
                 },
                 {
-                    "id": "Au7kJLKqCAY"
+                    "id": "KB5Mfe7zpOw"
                 },
                 {
-                    "id": "bOokLlHM9no"
+                    "id": "sYO8lQMbA7f"
                 }
             ]
         },
@@ -21619,52 +21676,52 @@
             "id": "qk2FihwV6IL",
             "categoryOptionCombos": [
                 {
-                    "id": "kx33GL2khoi"
+                    "id": "kYnK9rhdUYO"
                 },
                 {
-                    "id": "nwv02VfyQuz"
+                    "id": "RZeJX0Tg9Tx"
                 },
                 {
-                    "id": "rgEN46cGauU"
+                    "id": "gRb1QRLyCUZ"
                 },
                 {
-                    "id": "i4nidjHBsme"
+                    "id": "xCnBGy67HEN"
                 }
             ]
         },
         "new": {
             "code": "NEW",
-            "id": "S2y8dcmR2kD",
+            "id": "KiK0FMExoqh",
             "categoryOptionCombos": [
                 {
-                    "id": "UU2P0YSJM8A"
+                    "id": "aoRpDH3cNkD"
                 },
                 {
-                    "id": "bOokLlHM9no"
+                    "id": "kYnK9rhdUYO"
                 },
                 {
-                    "id": "kx33GL2khoi"
+                    "id": "KB5Mfe7zpOw"
                 },
                 {
-                    "id": "nwv02VfyQuz"
+                    "id": "RZeJX0Tg9Tx"
                 }
             ]
         },
         "recurring": {
             "code": "RETURNING",
-            "id": "CyILz2yY8ey",
+            "id": "a6AJLXQy8vO",
             "categoryOptionCombos": [
                 {
-                    "id": "xgT2W9JaXTq"
+                    "id": "TK1REL6Fx4k"
                 },
                 {
-                    "id": "Au7kJLKqCAY"
+                    "id": "sYO8lQMbA7f"
                 },
                 {
-                    "id": "rgEN46cGauU"
+                    "id": "gRb1QRLyCUZ"
                 },
                 {
-                    "id": "i4nidjHBsme"
+                    "id": "xCnBGy67HEN"
                 }
             ]
         },
@@ -21673,7 +21730,7 @@
             "id": "imyqCWQ229K",
             "categoryOptionCombos": [
                 {
-                    "id": "H8Sj3601jDn"
+                    "id": "J5W5ysZYXJ0"
                 }
             ]
         }
@@ -21687,7 +21744,7 @@
     "dataApprovalWorkflows": {
         "project": {
             "code": "PM_PROJECT",
-            "id": "SXvbJzbogqj"
+            "id": "CCy0oNyvlV1"
         }
     },
     "countries": [
@@ -21778,15 +21835,85 @@
             "id": "mGK0RBQPqAr",
             "displayName": "Country Admin Bahamas"
         },
+        "ADMIN_COUNTRY_BOLIVIA": {
+            "code": "ADMIN_COUNTRY_BOLIVIA",
+            "id": "eMMnyDXhCWl",
+            "displayName": "Country Admin Bolivia"
+        },
+        "ADMIN_COUNTRY_CAMBODIA": {
+            "code": "ADMIN_COUNTRY_CAMBODIA",
+            "id": "io6HkpCyPKc",
+            "displayName": "Country Admin Cambodia"
+        },
+        "ADMIN_COUNTRY_COLOMBIA": {
+            "code": "ADMIN_COUNTRY_COLOMBIA",
+            "id": "WckHObgJOBD",
+            "displayName": "Country Admin Colombia"
+        },
+        "ADMIN_COUNTRY_DRC": {
+            "code": "ADMIN_COUNTRY_DRC",
+            "id": "CUai08R52wI",
+            "displayName": "Country Admin DRC"
+        },
+        "ADMIN_COUNTRY_ETHIOPIA": {
+            "code": "ADMIN_COUNTRY_ETHIOPIA",
+            "id": "u2c9agogTV0",
+            "displayName": "Country Admin Ethiopia"
+        },
+        "ADMIN_COUNTRY_HAITI": {
+            "code": "ADMIN_COUNTRY_HAITI",
+            "id": "qS0eBMDbvI5",
+            "displayName": "Country Admin Haiti"
+        },
+        "ADMIN_COUNTRY_IRAQ": {
+            "code": "ADMIN_COUNTRY_IRAQ",
+            "id": "SqqklGMwRSN",
+            "displayName": "Country Admin Iraq"
+        },
+        "ADMIN_COUNTRY_KENYA": {
+            "code": "ADMIN_COUNTRY_KENYA",
+            "id": "icjgvYw6OJN",
+            "displayName": "Country Admin Kenya"
+        },
+        "ADMIN_COUNTRY_LIBERIA": {
+            "code": "ADMIN_COUNTRY_LIBERIA",
+            "id": "uqw5DU4FQAn",
+            "displayName": "Country Admin Liberia"
+        },
+        "ADMIN_COUNTRY_MYANMAR": {
+            "code": "ADMIN_COUNTRY_MYANMAR",
+            "id": "aMKMOjaMWRK",
+            "displayName": "Country Admin Myanmar"
+        },
+        "ADMIN_COUNTRY_NIGER": {
+            "code": "ADMIN_COUNTRY_NIGER",
+            "id": "Wg4gjOV58AK",
+            "displayName": "Country Admin Niger"
+        },
         "ADMIN_COUNTRY_PHILIPPINES": {
             "code": "ADMIN_COUNTRY_PHILIPPINES",
             "id": "CqMZCNVJup4",
             "displayName": "Country Admin Philippines"
         },
-        "PROJECT_MONITORING_ADMIN": {
-            "code": "PROJECT_MONITORING_ADMIN",
-            "id": "KAQv2ZlGCLn",
-            "displayName": "Project Monitoring Admin"
+        "ADMIN_COUNTRY_SOUTH SUDAN": {
+            "code": "ADMIN_COUNTRY_SOUTH SUDAN",
+            "id": "m2mQ90hSUde",
+            "displayName": "Country Admin South Sudan"
+        },
+        "ADMIN_COUNTRY_UGANDA": {
+            "code": "ADMIN_COUNTRY_UGANDA",
+            "id": "qO2FWU9IW5S",
+            "displayName": "Country Admin Uganda"
+        },
+        "ADMIN_COUNTRY_VIETNAM": {
+            "code": "ADMIN_COUNTRY_VIETNAM",
+            "id": "uIEh8uza2Cg",
+            "displayName": "Country Admin Vietnam"
+        },
+        "DATA_MANAGEMENT_ADMIN": {
+            "code": "DATA_MANAGEMENT_ADMIN",
+            "id": "mKKNXzeIAJs",
+            "displayName": "Data Management Admin"
         },
         "SYSTEM_ADMIN": {
             "code": "SYSTEM_ADMIN",

--- a/src/models/__tests__/config.json
+++ b/src/models/__tests__/config.json
@@ -5,10 +5,10 @@
             "levelForProjects": 3
         },
         "userRoles": {
-            "feedback": ["PM Feedback"],
+            "feedback": ["DM Feedback"],
             "dataReviewer": ["Data Reviewer"],
             "dataViewer": ["Data Viewer"],
-            "admin": ["PM Admin"],
+            "admin": ["DM Admin"],
             "dataEntry": ["Data Entry"]
         },
         "dataElementGroupSets": {
@@ -19,12 +19,12 @@
             "externals": "EXTERNAL"
         },
         "attributes": {
-            "pairedDataElement": "PM_PAIRED_DE",
-            "createdByApp": "PM_CREATED_BY_DATA_MANAGEMENT",
-            "orgUnitProject": "PM_ORGUNIT_PROJECT_ID",
-            "projectDashboard": "PM_PROJECT_DASHBOARD_ID",
-            "countingMethod": "PM_COUNTING_METHOD",
-            "mainSector": "PM_MAIN_SECTOR"
+            "pairedDataElement": "DM_PAIRED_DE",
+            "createdByApp": "DM_CREATED_BY_DATA_MANAGEMENT",
+            "orgUnitProject": "DM_ORGUNIT_PROJECT_ID",
+            "projectDashboard": "DM_PROJECT_DASHBOARD_ID",
+            "countingMethod": "DM_COUNTING_METHOD",
+            "mainSector": "DM_MAIN_SECTOR"
         },
         "categories": {
             "default": "default",
@@ -68,7 +68,7 @@
             "costBenefitPrefix": "COST_BENEFIT_"
         },
         "dataApprovalWorkflows": {
-            "project": "PM_PROJECT"
+            "project": "DM_PROJECT"
         },
         "userGroups": {
             "systemAdmin": "SYSTEM_ADMIN",
@@ -83,7 +83,7 @@
             "username": "admin",
             "userRoles": [
                 {
-                    "name": "PM Admin"
+                    "name": "DM Admin"
                 },
                 {
                     "name": "Metadata Maintainer"
@@ -92,7 +92,7 @@
                     "name": "Superuser"
                 },
                 {
-                    "name": "PM Feedback"
+                    "name": "DM Feedback"
                 }
             ]
         },
@@ -180,7 +180,7 @@
         ],
         "userRoles": [
             {
-                "name": "PM Admin"
+                "name": "DM Admin"
             },
             {
                 "name": "Metadata Maintainer"
@@ -189,7 +189,7 @@
                 "name": "Superuser"
             },
             {
-                "name": "PM Feedback"
+                "name": "DM Feedback"
             }
         ],
         "username": "admin"
@@ -21056,27 +21056,27 @@
     ],
     "attributes": {
         "countingMethod": {
-            "code": "PM_COUNTING_METHOD",
+            "code": "DM_COUNTING_METHOD",
             "id": "OOi8Yw1TrmS"
         },
         "createdByApp": {
-            "code": "PM_CREATED_BY_DATA_MANAGEMENT",
+            "code": "DM_CREATED_BY_DATA_MANAGEMENT",
             "id": "mgCKcJuP5n0"
         },
         "mainSector": {
-            "code": "PM_MAIN_SECTOR",
+            "code": "DM_MAIN_SECTOR",
             "id": "qqqopVltY52"
         },
         "orgUnitProject": {
-            "code": "PM_ORGUNIT_PROJECT_ID",
+            "code": "DM_ORGUNIT_PROJECT_ID",
             "id": "qgSqj6sBF7j"
         },
         "pairedDataElement": {
-            "code": "PM_PAIRED_DE",
+            "code": "DM_PAIRED_DE",
             "id": "qeayiIiTONg"
         },
         "projectDashboard": {
-            "code": "PM_PROJECT_DASHBOARD_ID",
+            "code": "DM_PROJECT_DASHBOARD_ID",
             "id": "aywduilEjPQ"
         }
     },
@@ -21743,7 +21743,7 @@
     },
     "dataApprovalWorkflows": {
         "project": {
-            "code": "PM_PROJECT",
+            "code": "DM_PROJECT",
             "id": "CCy0oNyvlV1"
         }
     },

--- a/src/models/__tests__/data/project-download-people-analytics.json
+++ b/src/models/__tests__/data/project-download-people-analytics.json
@@ -33,8 +33,8 @@
             "meta": true
         },
         {
-            "name": "a0Cy1qwUuZv",
-            "column": "New/Recurring",
+            "name": "uSMHdwhxFSV",
+            "column": "New-Returning",
             "valueType": "TEXT",
             "type": "java.lang.String",
             "hidden": false,
@@ -59,40 +59,90 @@
     ],
     "metaData": {
         "items": {
-            "imyqCWQ229K": { "name": "Target" },
-            "yMqK9DKbA3X": { "name": "# of livelihood inputs/ assets provided" },
-            "GIIHAr9BzzO": { "name": "Actual/Target" },
-            "Kyg1O6YEGa9": { "name": "Gender" },
+            "imyqCWQ229K": {
+                "name": "Target"
+            },
+            "yMqK9DKbA3X": {
+                "name": "# of livelihood inputs/ assets provided"
+            },
+            "GIIHAr9BzzO": {
+                "name": "Actual/Target"
+            },
+            "Kyg1O6YEGa9": {
+                "name": "Gender"
+            },
             "WS8XV4WWPE7": {
                 "name": "# of agriculture groups receiving support for improved livelihoods"
             },
-            "eWeQoOlAcxV": { "name": "Actual" },
-            "202004": { "name": "April 2020" },
-            "ik0ICagvIjm": { "name": "# of people trained on agronomic practices" },
-            "CyILz2yY8ey": { "name": "Recurring" },
-            "a0Cy1qwUuZv": { "name": "New/Recurring" },
-            "WGC0DJ0YSis": { "name": "0Test1-22569" },
-            "dx": { "name": "Data" },
-            "S2y8dcmR2kD": { "name": "New" },
-            "MZyzwIh5xGW": { "name": "Female, New" },
-            "We61YNYyOX0": { "name": "# of biogas digesters installed" },
-            "ou": { "name": "Organisation unit" },
+            "eWeQoOlAcxV": {
+                "name": "Actual"
+            },
+            "202004": {
+                "name": "April 2020"
+            },
+            "ik0ICagvIjm": {
+                "name": "# of people trained on agronomic practices"
+            },
+            "a6AJLXQy8vO": {
+                "name": "Returning"
+            },
+            "uSMHdwhxFSV": {
+                "name": "New-Returning"
+            },
+            "WGC0DJ0YSis": {
+                "name": "0Test1-22569"
+            },
+            "dx": {
+                "name": "Data"
+            },
+            "KiK0FMExoqh": {
+                "name": "New"
+            },
+            "MZyzwIh5xGW": {
+                "name": "Female, New"
+            },
+            "We61YNYyOX0": {
+                "name": "# of biogas digesters installed"
+            },
+            "ou": {
+                "name": "Organisation unit"
+            },
             "K6mAC5SiO29": {
                 "name": "# of people trained on improved agriculture technologies/practices"
             },
-            "202002": { "name": "February 2020" },
-            "202003": { "name": "March 2020" },
-            "mESy6ndYTwW": { "name": "Male, New" },
-            "202001": { "name": "January 2020" },
-            "pe": { "name": "Period" },
-            "Q5IlmX3qedn": { "name": "Female, Recurring" },
-            "HllvX50cXC0": { "name": "default" },
-            "MWVFqIu6s0C": { "name": "Male, Recurring" },
-            "yW2hYVS3S4u": { "name": "Female" },
-            "qk2FihwV6IL": { "name": "Male" }
+            "202002": {
+                "name": "February 2020"
+            },
+            "202003": {
+                "name": "March 2020"
+            },
+            "mESy6ndYTwW": {
+                "name": "Male, New"
+            },
+            "202001": {
+                "name": "January 2020"
+            },
+            "pe": {
+                "name": "Period"
+            },
+            "Q5IlmX3qedn": {
+                "name": "Female, Returning"
+            },
+            "HllvX50cXC0": {
+                "name": "default"
+            },
+            "MWVFqIu6s0C": {
+                "name": "Male, Returning"
+            },
+            "yW2hYVS3S4u": {
+                "name": "Female"
+            },
+            "qk2FihwV6IL": {
+                "name": "Male"
+            }
         },
         "dimensions": {
-            "a0Cy1qwUuZv": ["S2y8dcmR2kD", "CyILz2yY8ey"],
+            "uSMHdwhxFSV": ["KiK0FMExoqh", "a6AJLXQy8vO"],
             "GIIHAr9BzzO": ["imyqCWQ229K", "eWeQoOlAcxV"],
             "dx": ["WS8XV4WWPE7", "ik0ICagvIjm", "K6mAC5SiO29", "We61YNYyOX0", "yMqK9DKbA3X"],
             "pe": ["202001", "202002", "202003", "202004"],
@@ -109,7 +159,7 @@
             "WGC0DJ0YSis",
             "202001",
             "imyqCWQ229K",
-            "CyILz2yY8ey",
+            "a6AJLXQy8vO",
             "qk2FihwV6IL",
             "7.0"
         ],
@@ -118,7 +168,7 @@
             "WGC0DJ0YSis",
             "202001",
             "eWeQoOlAcxV",
-            "S2y8dcmR2kD",
+            "KiK0FMExoqh",
             "yW2hYVS3S4u",
             "4.0"
         ],
@@ -127,7 +177,7 @@
             "WGC0DJ0YSis",
             "202001",
             "eWeQoOlAcxV",
-            "CyILz2yY8ey",
+            "a6AJLXQy8vO",
             "qk2FihwV6IL",
             "2.0"
         ],
@@ -136,7 +186,7 @@
             "WGC0DJ0YSis",
             "202004",
             "imyqCWQ229K",
-            "CyILz2yY8ey",
+            "a6AJLXQy8vO",
             "qk2FihwV6IL",
             "5.0"
         ],
@@ -145,7 +195,7 @@
             "WGC0DJ0YSis",
             "202002",
             "imyqCWQ229K",
-            "CyILz2yY8ey",
+            "a6AJLXQy8vO",
             "yW2hYVS3S4u",
             "2.0"
         ],
@@ -154,7 +204,7 @@
             "WGC0DJ0YSis",
             "202001",
             "eWeQoOlAcxV",
-            "CyILz2yY8ey",
+            "a6AJLXQy8vO",
             "qk2FihwV6IL",
             "9.0"
         ],
@@ -163,7 +213,7 @@
             "WGC0DJ0YSis",
             "202002",
             "imyqCWQ229K",
-            "S2y8dcmR2kD",
+            "KiK0FMExoqh",
             "qk2FihwV6IL",
             "1.0"
         ],
@@ -172,7 +222,7 @@
             "WGC0DJ0YSis",
             "202003",
             "imyqCWQ229K",
-            "S2y8dcmR2kD",
+            "KiK0FMExoqh",
             "yW2hYVS3S4u",
             "5.0"
         ],
@@ -181,7 +231,7 @@
             "WGC0DJ0YSis",
             "202003",
             "imyqCWQ229K",
-            "S2y8dcmR2kD",
+            "KiK0FMExoqh",
             "qk2FihwV6IL",
             "7.0"
         ],
@@ -190,7 +240,7 @@
             "WGC0DJ0YSis",
             "202003",
             "imyqCWQ229K",
-            "S2y8dcmR2kD",
+            "KiK0FMExoqh",
             "yW2hYVS3S4u",
             "4.0"
         ],
@@ -199,7 +249,7 @@
             "WGC0DJ0YSis",
             "202002",
             "imyqCWQ229K",
-            "CyILz2yY8ey",
+            "a6AJLXQy8vO",
             "yW2hYVS3S4u",
             "4.0"
         ],
@@ -208,7 +258,7 @@
             "WGC0DJ0YSis",
             "202004",
             "imyqCWQ229K",
-            "CyILz2yY8ey",
+            "a6AJLXQy8vO",
             "yW2hYVS3S4u",
             "4.0"
         ],
@@ -217,7 +267,7 @@
             "WGC0DJ0YSis",
             "202004",
             "imyqCWQ229K",
-            "S2y8dcmR2kD",
+            "KiK0FMExoqh",
             "yW2hYVS3S4u",
             "10.0"
         ],
@@ -226,7 +276,7 @@
             "WGC0DJ0YSis",
             "202003",
             "imyqCWQ229K",
-            "CyILz2yY8ey",
+            "a6AJLXQy8vO",
             "qk2FihwV6IL",
             "3.0"
         ],
@@ -235,7 +285,7 @@
             "WGC0DJ0YSis",
             "202003",
             "imyqCWQ229K",
-            "S2y8dcmR2kD",
+            "KiK0FMExoqh",
             "qk2FihwV6IL",
             "10.0"
         ],
@@ -244,7 +294,7 @@
             "WGC0DJ0YSis",
             "202001",
             "imyqCWQ229K",
-            "S2y8dcmR2kD",
+            "KiK0FMExoqh",
             "qk2FihwV6IL",
             "3.0"
         ],
@@ -253,7 +303,7 @@
             "WGC0DJ0YSis",
             "202001",
             "imyqCWQ229K",
-            "S2y8dcmR2kD",
+            "KiK0FMExoqh",
             "yW2hYVS3S4u",
             "2.0"
         ],
@@ -262,7 +312,7 @@
             "WGC0DJ0YSis",
             "202001",
             "imyqCWQ229K",
-            "CyILz2yY8ey",
+            "a6AJLXQy8vO",
             "qk2FihwV6IL",
             "3.0"
         ],
@@ -271,7 +321,7 @@
             "WGC0DJ0YSis",
             "202001",
             "imyqCWQ229K",
-            "CyILz2yY8ey",
+            "a6AJLXQy8vO",
             "yW2hYVS3S4u",
             "9.0"
         ],
@@ -280,7 +330,7 @@
             "WGC0DJ0YSis",
             "202002",
             "imyqCWQ229K",
-            "S2y8dcmR2kD",
+            "KiK0FMExoqh",
             "yW2hYVS3S4u",
             "2.0"
         ],
@@ -289,7 +339,7 @@
             "WGC0DJ0YSis",
             "202001",
             "eWeQoOlAcxV",
-            "S2y8dcmR2kD",
+            "KiK0FMExoqh",
             "qk2FihwV6IL",
             "6.0"
         ],
@@ -298,7 +348,7 @@
             "WGC0DJ0YSis",
             "202002",
             "imyqCWQ229K",
-            "S2y8dcmR2kD",
+            "KiK0FMExoqh",
             "yW2hYVS3S4u",
             "3.0"
         ],
@@ -307,7 +357,7 @@
             "WGC0DJ0YSis",
             "202004",
             "imyqCWQ229K",
-            "S2y8dcmR2kD",
+            "KiK0FMExoqh",
             "qk2FihwV6IL",
             "4.0"
         ],
@@ -316,7 +366,7 @@
             "WGC0DJ0YSis",
             "202001",
             "eWeQoOlAcxV",
-            "CyILz2yY8ey",
+            "a6AJLXQy8vO",
             "yW2hYVS3S4u",
             "3.0"
         ],
@@ -325,7 +375,7 @@
             "WGC0DJ0YSis",
             "202003",
             "imyqCWQ229K",
-            "CyILz2yY8ey",
+            "a6AJLXQy8vO",
             "yW2hYVS3S4u",
             "2.0"
         ],
@@ -334,7 +384,7 @@
             "WGC0DJ0YSis",
             "202001",
             "eWeQoOlAcxV",
-            "S2y8dcmR2kD",
+            "KiK0FMExoqh",
             "qk2FihwV6IL",
             "4.0"
         ],
@@ -343,7 +393,7 @@
             "WGC0DJ0YSis",
             "202003",
             "imyqCWQ229K",
-            "CyILz2yY8ey",
+            "a6AJLXQy8vO",
             "yW2hYVS3S4u",
             "5.0"
         ],
@@ -352,7 +402,7 @@
             "WGC0DJ0YSis",
             "202002",
             "imyqCWQ229K",
-            "CyILz2yY8ey",
+            "a6AJLXQy8vO",
             "qk2FihwV6IL",
             "10.0"
         ],
@@ -361,7 +411,7 @@
             "WGC0DJ0YSis",
             "202003",
             "imyqCWQ229K",
-            "CyILz2yY8ey",
+            "a6AJLXQy8vO",
             "qk2FihwV6IL",
             "1.0"
         ],
@@ -370,7 +420,7 @@
             "WGC0DJ0YSis",
             "202002",
             "imyqCWQ229K",
-            "S2y8dcmR2kD",
+            "KiK0FMExoqh",
             "qk2FihwV6IL",
             "7.0"
         ],
@@ -379,7 +429,7 @@
             "WGC0DJ0YSis",
             "202002",
             "imyqCWQ229K",
-            "CyILz2yY8ey",
+            "a6AJLXQy8vO",
             "qk2FihwV6IL",
             "8.0"
         ],
@@ -388,7 +438,7 @@
             "WGC0DJ0YSis",
             "202001",
             "eWeQoOlAcxV",
-            "CyILz2yY8ey",
+            "a6AJLXQy8vO",
             "yW2hYVS3S4u",
             "6.0"
         ],
@@ -397,7 +447,7 @@
             "WGC0DJ0YSis",
             "202001",
             "imyqCWQ229K",
-            "S2y8dcmR2kD",
+            "KiK0FMExoqh",
             "yW2hYVS3S4u",
             "1.0"
         ],
@@ -406,7 +456,7 @@
             "WGC0DJ0YSis",
             "202001",
             "eWeQoOlAcxV",
-            "S2y8dcmR2kD",
+            "KiK0FMExoqh",
             "yW2hYVS3S4u",
             "8.0"
         ],
@@ -415,7 +465,7 @@
             "WGC0DJ0YSis",
             "202001",
             "imyqCWQ229K",
-            "CyILz2yY8ey",
+            "a6AJLXQy8vO",
             "yW2hYVS3S4u",
             "5.0"
         ],
@@ -424,7 +474,7 @@
             "WGC0DJ0YSis",
             "202004",
             "imyqCWQ229K",
-            "S2y8dcmR2kD",
+            "KiK0FMExoqh",
             "qk2FihwV6IL",
             "5.0"
         ],
@@ -433,7 +483,7 @@
             "WGC0DJ0YSis",
             "202004",
             "imyqCWQ229K",
-            "S2y8dcmR2kD",
+            "KiK0FMExoqh",
             "yW2hYVS3S4u",
             "10.0"
         ],
@@ -442,7 +492,7 @@
             "WGC0DJ0YSis",
             "202004",
             "imyqCWQ229K",
-            "CyILz2yY8ey",
+            "a6AJLXQy8vO",
             "yW2hYVS3S4u",
             "8.0"
         ],
@@ -451,7 +501,7 @@
             "WGC0DJ0YSis",
             "202001",
             "imyqCWQ229K",
-            "S2y8dcmR2kD",
+            "KiK0FMExoqh",
             "qk2FihwV6IL",
             "6.0"
         ],
@@ -460,7 +510,7 @@
             "WGC0DJ0YSis",
             "202004",
             "imyqCWQ229K",
-            "CyILz2yY8ey",
+            "a6AJLXQy8vO",
             "qk2FihwV6IL",
             "10.0"
         ]

--- a/src/models/__tests__/mer-data.ts
+++ b/src/models/__tests__/mer-data.ts
@@ -16,7 +16,7 @@ export function mockApiForMerReportEmpty(mock: MockAdapter) {
 
 export function mockApiForMerReportWithData(mock: MockAdapter) {
     mock.reset();
-    mock.onGet("/dataStore/project-monitoring-app/mer-PJb0RtEnqlf").replyOnce(200, {
+    mock.onGet("/dataStore/data-management-app/mer-PJb0RtEnqlf").replyOnce(200, {
         reports: {
             201912: {
                 created: "2019-12-17T17:21:23",
@@ -44,10 +44,10 @@ export function mockApiForMerReportWithData(mock: MockAdapter) {
             },
         },
     });
-    mock.onGet("/dataStore/project-monitoring-app/project-uWuM0QT2pVl").replyOnce(200, {
+    mock.onGet("/dataStore/data-management-app/project-uWuM0QT2pVl").replyOnce(200, {
         merDataElementIds: ["WS8XV4WWPE7", "We61YNYyOX0"],
     });
-    mock.onGet("/dataStore/project-monitoring-app/project-SKuiiu7Vbwv").replyOnce(200, {
+    mock.onGet("/dataStore/data-management-app/project-SKuiiu7Vbwv").replyOnce(200, {
         merDataElementIds: ["yUGuwPFkBrj"],
     });
     mock.onGet("/metadata", {

--- a/src/utils/dhis2.ts
+++ b/src/utils/dhis2.ts
@@ -48,7 +48,7 @@ export async function postMetadataRequests(
 }
 
 export function getDataStore(api: D2Api) {
-    return api.dataStore("project-monitoring-app");
+    return api.dataStore("data-management-app");
 }
 
 // DHIS2 UID :: /^[a-zA-Z][a-zA-Z0-9]{10}$/


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #252 

Requires https://bitbucket.org/eyeseetea/project-monitoring-metadata/pull-requests/20/rename-app-project-monitoring-data

Not deployed to dev.est:8087, I'll wait until the other PRs are merged.

### :memo: Implementation

- Renamed: createdByApp attribute, dataStore namespace. Projects must be removed and created with new medatata.
- New metadata is not yet committed to the docker image, so Travis won't pass. I'll wait until all other PRs are merged and then update the docker image.
- User group "Project Monitoring Admin" can be deleted after deploying new metadata/users.

