### PR TITLE
[MER] Limit executive summaries to three selectable sectors [cay3mw]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-01-08T09:23:01.586Z\n"
-"PO-Revision-Date: 2021-01-08T09:23:01.586Z\n"
+"POT-Creation-Date: 2021-01-18T12:15:51.763Z\n"
+"PO-Revision-Date: 2021-01-18T12:15:51.763Z\n"
 
 msgid "Name"
 msgstr ""
@@ -156,6 +156,9 @@ msgid "This user has no Data output and analytic organisation units assigned"
 msgstr ""
 
 msgid "Back"
+msgstr ""
+
+msgid "Executive Summary"
 msgstr ""
 
 msgid "Internals"
@@ -324,9 +327,6 @@ msgid "Country Director"
 msgstr ""
 
 msgid "Prepared by"
-msgstr ""
-
-msgid "Executive Summary"
 msgstr ""
 
 msgid "Ministry Summary"
@@ -830,6 +830,9 @@ msgid "Target to date"
 msgstr ""
 
 msgid "Actual to date"
+msgstr ""
+
+msgid "Sector"
 msgstr ""
 
 msgid "{{field}} cannot be blank"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-01-18T12:15:51.763Z\n"
-"PO-Revision-Date: 2021-01-18T12:15:51.763Z\n"
+"POT-Creation-Date: 2021-01-19T09:53:30.902Z\n"
+"PO-Revision-Date: 2021-01-19T09:53:30.902Z\n"
 
 msgid "Name"
 msgstr ""
@@ -852,10 +852,10 @@ msgstr ""
 msgid "Actual to date"
 msgstr ""
 
-msgid "Sector"
+msgid "Achieved to date (%)"
 msgstr ""
 
-msgid "Achieved to date (%)"
+msgid "Sector"
 msgstr ""
 
 msgid "{{field}} cannot be blank"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "data-management-app",
     "description": "DHIS2 Data Management App",
-    "version": "0.8.1",
+    "version": "0.9.0",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "homepage": ".",

--- a/src/components/dropdown/Dropdown.tsx
+++ b/src/components/dropdown/Dropdown.tsx
@@ -14,22 +14,20 @@ export interface DropdownProps {
     label?: string;
     value?: Value;
     hideEmpty?: boolean;
+    hideLabelWhenValueSelected?: boolean;
 }
 
 const Dropdown: React.FC<DropdownProps> = props => {
-    const { items, value, onChange, label, hideEmpty, id } = props;
+    const { items, value, onChange, hideEmpty, id } = props;
+    const { label, hideLabelWhenValueSelected = false } = props;
+
     const selectValue =
         value === undefined || !items.map(item => item.value).includes(value) ? "" : value;
 
-    const SelectWrapper = (props: any) =>
-        label ? (
-            <DropdownForm label={label}>{props.children}</DropdownForm>
-        ) : (
-            <React.Fragment>{props.children}</React.Fragment>
-        );
+    const isLabelVisible = hideLabelWhenValueSelected ? !selectValue : true;
 
     return (
-        <SelectWrapper>
+        <SelectWrapper label={label} visible={isLabelVisible}>
             <Select
                 data-cy={id}
                 value={selectValue}
@@ -48,6 +46,16 @@ const Dropdown: React.FC<DropdownProps> = props => {
             </Select>
         </SelectWrapper>
     );
+};
+
+const SelectWrapper: React.FC<{ label?: string; visible: boolean }> = props => {
+    const { label, visible, children } = props;
+
+    if (label) {
+        return <DropdownForm label={visible ? label : ""}>{children}</DropdownForm>;
+    } else {
+        return <React.Fragment>{children}</React.Fragment>;
+    }
 };
 
 export default React.memo(Dropdown);

--- a/src/components/report/ExecutiveSummaries.tsx
+++ b/src/components/report/ExecutiveSummaries.tsx
@@ -1,0 +1,61 @@
+import * as React from "react";
+
+import i18n from "../../locales";
+import MerReport, { ExecutiveSummaries } from "../../models/MerReport";
+import ReportTextFieldForSector, {
+    ReportTextFieldForSectorProps,
+} from "../../pages/report/ReportTextFieldForSector";
+
+interface ExecutiveSummariesProps {
+    merReport: MerReport;
+    onChange(report: MerReport): void;
+}
+
+type OnBlurChange = ReportTextFieldForSectorProps<ExecutiveSummaries>["onBlurChange"];
+
+const ExecutiveSummariesComponent: React.FC<ExecutiveSummariesProps> = props => {
+    const { merReport, onChange } = props;
+
+    const notifyChange = React.useCallback<OnBlurChange>(
+        (_field, value) => {
+            const merReportUpdated = merReport.set("executiveSummaries", value);
+            onChange(merReportUpdated);
+        },
+        [merReport, onChange]
+    );
+
+    const executiveSummariesInfo = React.useMemo(() => {
+        return merReport.getExecutiveSummariesInfo();
+    }, [merReport]);
+
+    const onSectorChange = React.useCallback(
+        (idx: number, newSectorId: string | undefined) => {
+            const sectors = executiveSummariesInfo.map(o => o.sector);
+            const newSelected = sectors.map((sector, i) => (idx === i ? newSectorId : sector?.id));
+            const merReportUpdated = merReport.set("executiveSummariesSelected", newSelected);
+            onChange(merReportUpdated);
+        },
+        [executiveSummariesInfo, merReport, onChange]
+    );
+
+    return (
+        <React.Fragment>
+            {executiveSummariesInfo.map(({ sector, selectable, value }, idx) => (
+                <ReportTextFieldForSector<ExecutiveSummaries>
+                    key={idx}
+                    title={i18n.t("Executive Summary") + " - "}
+                    value={value}
+                    field="executiveSummaries"
+                    index={idx}
+                    parent={merReport.data.executiveSummaries}
+                    sector={sector}
+                    onBlurChange={notifyChange}
+                    onSectorChange={onSectorChange}
+                    sectors={selectable}
+                ></ReportTextFieldForSector>
+            ))}
+        </React.Fragment>
+    );
+};
+
+export default ExecutiveSummariesComponent;

--- a/src/models/Config.ts
+++ b/src/models/Config.ts
@@ -113,6 +113,7 @@ const baseConfig = {
     },
     merReports: {
         excludedSectors: ["SECTOR_MINISTRY"],
+        maxExecutiveSummaries: 3,
     },
 };
 

--- a/src/models/MerReport.ts
+++ b/src/models/MerReport.ts
@@ -221,12 +221,13 @@ class MerReport {
 
     public getExecutiveSummariesInfo(): ExecutiveSummariesInfo {
         const { sectors, executiveSummariesSelected } = this.data;
-        const limit = this.config.base.merReports.maxExecutiveSummaries;
+        const limit = Math.min(this.config.base.merReports.maxExecutiveSummaries, sectors.length);
         const sectorsById = _.keyBy(sectors, sector => sector.id);
 
-        const selectedSectors = executiveSummariesSelected.map(sectorId =>
-            sectorId ? sectorsById[sectorId] : undefined
-        );
+        const selectedSectors = _(executiveSummariesSelected)
+            .map(sectorId => (sectorId ? sectorsById[sectorId] : undefined))
+            .take(limit)
+            .value();
         const selectableSectors = _.differenceBy(
             sectors,
             _.compact(selectedSectors),
@@ -238,7 +239,7 @@ class MerReport {
             selectable: sector ? [sector, ...selectableSectors] : selectableSectors,
         }));
 
-        const padCount = Math.min(limit - selectedSectors.length, sectors.length);
+        const padCount = limit - selectedSectors.length;
         const infoForRemaining: ExecutiveSummariesInfo = _.range(0, padCount).map(() => ({
             selectable: selectableSectors,
         }));

--- a/src/models/MerReport.ts
+++ b/src/models/MerReport.ts
@@ -209,19 +209,19 @@ class MerReport {
         }));
     }
 
-    public getExecutiveSummariesForDownload(limit: number): ExecutiveSummariesList {
+    public getExecutiveSummariesForDownload(): ExecutiveSummariesList {
         return _(this.getExecutiveSummaries())
             .keyBy(o => o.sector.id)
             .at(_.compact(this.data.executiveSummariesSelected))
             .compact()
-            .take(limit)
+            .take(this.config.base.merReports.maxExecutiveSummaries)
             .filter(o => !!o.value)
             .value();
     }
 
-    public getExecutiveSummariesInfo(limit = 3): ExecutiveSummariesInfo {
+    public getExecutiveSummariesInfo(): ExecutiveSummariesInfo {
         const { sectors, executiveSummariesSelected } = this.data;
-
+        const limit = this.config.base.merReports.maxExecutiveSummaries;
         const sectorsById = _.keyBy(sectors, sector => sector.id);
 
         const selectedSectors = executiveSummariesSelected.map(sectorId =>

--- a/src/models/MerReportSpreadsheet.ts
+++ b/src/models/MerReportSpreadsheet.ts
@@ -92,7 +92,7 @@ class MerReportSpreadsheet {
             [],
             [bold(i18n.t("Executive Summary"), { colspan: 6 })],
             ...merReport
-                .getExecutiveSummariesForDownload(3)
+                .getExecutiveSummariesForDownload()
                 .map(({ sector, value }) => [
                     text(sector.displayName),
                     text(value, { colspan: 5 }),

--- a/src/models/MerReportSpreadsheet.ts
+++ b/src/models/MerReportSpreadsheet.ts
@@ -92,7 +92,7 @@ class MerReportSpreadsheet {
             [],
             [bold(i18n.t("Executive Summary"), { colspan: 6 })],
             ...merReport
-                .getExecutiveSummaries()
+                .getExecutiveSummariesForDownload(3)
                 .map(({ sector, value }) => [
                     text(sector.displayName),
                     text(value, { colspan: 5 }),

--- a/src/models/dev-project.ts
+++ b/src/models/dev-project.ts
@@ -68,7 +68,7 @@ export function getDevProject(initialProject: Project, enabled: boolean) {
 
 export function getDevMerReport() {
     return {
-        date: moment(),
+        date: moment(new Date(2020, 11, 30)),
         orgUnit: {
             path: "/AGZEUf9meZ6/WmczKCGK8FQ",
             id: "WmczKCGK8FQ",

--- a/src/pages/report/MerReport.tsx
+++ b/src/pages/report/MerReport.tsx
@@ -20,7 +20,7 @@ import { downloadFile } from "../../utils/download";
 import { useBoolean } from "../../utils/hooks";
 import { Maybe } from "../../types/utils";
 import { withSnackbarOnError } from "../../components/utils/errors";
-import ReportTextFieldForSector from "./ReportTextFieldForSector";
+import ExecutiveSummaries from "../../components/report/ExecutiveSummaries";
 
 type ProceedWarning = { type: "hidden" } | { type: "visible"; action: () => void };
 
@@ -123,10 +123,6 @@ const MerReportComponent: React.FC = () => {
         [confirmIfUnsavedChanges]
     );
 
-    const executiveSummaries = React.useMemo(() => {
-        return merReport ? merReport.getExecutiveSummaries() : [];
-    }, [merReport]);
-
     return (
         <React.Fragment>
             {proceedWarning.type === "visible" && (
@@ -182,17 +178,7 @@ const MerReportComponent: React.FC = () => {
                     <ReportDataTable merReport={merReport} onChange={setMerReport} />
 
                     <Paper>
-                        {executiveSummaries.map(({ sector, value }) => (
-                            <ReportTextFieldForSector
-                                key={sector.id}
-                                title={i18n.t("Executive Summary") + " - " + sector.displayName}
-                                value={value || ""}
-                                field="executiveSummaries"
-                                sector={sector}
-                                parent={merReport.data.executiveSummaries}
-                                onBlurChange={onChange}
-                            />
-                        ))}
+                        <ExecutiveSummaries merReport={merReport} onChange={setMerReport} />
 
                         <ReportTextField
                             title={i18n.t("Additional comments")}

--- a/src/pages/report/ReportTextField.tsx
+++ b/src/pages/report/ReportTextField.tsx
@@ -5,13 +5,25 @@ import { TextFieldProps } from "@material-ui/core/TextField";
 
 export type ReportTextFieldProps = TextFieldProps & {
     title: string;
-    value: string;
+    value: string | undefined;
     field: string;
+    minVisibleRows?: number;
+    maxVisibleRows?: number;
+    maxContentRows?: number;
     onBlurChange(field: string, value: string): void;
 };
 
 const ReportTextField: React.FC<ReportTextFieldProps> = props => {
-    const { title, field, value, onBlurChange, ...otherProps } = props;
+    const {
+        title,
+        field,
+        value,
+        onBlurChange,
+        children,
+        minVisibleRows = 4,
+        maxVisibleRows = 10,
+        ...otherProps
+    } = props;
     const notifyChange = React.useCallback(
         (value: string) => {
             onBlurChange(field, value);
@@ -23,15 +35,17 @@ const ReportTextField: React.FC<ReportTextFieldProps> = props => {
         <div style={{ marginTop: 10, marginBottom: 10, padding: 10 }}>
             <div style={{ fontSize: "1.1em", color: "grey", marginTop: 10, marginBottom: 10 }}>
                 {title}
+                {children}
             </div>
 
             <TextFieldOnBlur
-                value={value}
+                value={value || ""}
+                disabled={value === undefined}
                 multiline={true}
                 fullWidth={true}
                 style={{ border: "1px solid #EEE" }}
-                rows={getMultilineRows(value, 4, 10)}
-                rowsMax={10}
+                rows={getMultilineRows(value, minVisibleRows, maxVisibleRows)}
+                rowsMax={maxVisibleRows}
                 onBlurChange={notifyChange}
                 InputProps={{ style: { margin: 10 } }}
                 {...otherProps}

--- a/src/pages/report/ReportTextFieldForSector.tsx
+++ b/src/pages/report/ReportTextFieldForSector.tsx
@@ -1,25 +1,73 @@
 import React from "react";
-import { Ref } from "../../types/d2-api";
+import _ from "lodash";
+import { Id } from "../../types/d2-api";
 import ReportTextField, { ReportTextFieldProps } from "./ReportTextField";
+import i18n from "../../locales";
+import Dropdown, { DropdownProps } from "../../components/dropdown/Dropdown";
+import { reactMemo } from "../../utils/react";
 
-export type ReportTextFieldForSectorProps = ReportTextFieldProps & {
-    sector: Ref;
-    onBlurChange(field: string, value: object): void;
-    parent: object;
+export type ReportTextFieldForSectorProps<Value> = Omit<ReportTextFieldProps, "onBlurChange"> & {
+    sectors: Array<{ id: Id; displayName: string }>;
+    sector?: { id: Id; displayName: string };
+    onSectorChange(index: number, sectorId: Id | undefined): void;
+    onBlurChange(field: string, value: Value): void;
+    parent: Value;
+    index: number;
 };
 
-export const ReportTextFieldForSector: React.FC<ReportTextFieldForSectorProps> = props => {
-    const { sector, parent, onBlurChange, ...otherProps } = props;
+export function ReportTextFieldForSector<Value>(props: ReportTextFieldForSectorProps<Value>) {
+    const { sector, parent, onBlurChange, sectors, onSectorChange, index, ...otherProps } = props;
 
     const notifyChange = React.useCallback(
         (field: string, value: string) => {
-            const mergedValue = { ...parent, [sector.id]: value };
-            onBlurChange(field, mergedValue);
+            if (sector) {
+                const mergedValue = { ...parent, [sector.id]: value };
+                onBlurChange(field, mergedValue);
+            }
         },
         [onBlurChange, parent, sector]
     );
 
-    return <ReportTextField {...otherProps} onBlurChange={notifyChange} />;
+    const sectorItems = React.useMemo(() => {
+        return _(sectors)
+            .sortBy(sector => sector.displayName)
+            .map(sector => ({
+                value: sector.id,
+                text: sector.displayName,
+            }))
+            .value();
+    }, [sectors]);
+
+    const notifySectorChange = React.useCallback<DropdownProps["onChange"]>(
+        (sectorId: string | undefined) => {
+            onSectorChange(index, sectorId);
+        },
+        [index, onSectorChange]
+    );
+
+    return (
+        <ReportTextField
+            {...otherProps}
+            minVisibleRows={3}
+            maxVisibleRows={3}
+            maxContentRows={3}
+            onBlurChange={notifyChange}
+        >
+            <span style={styles.dropdown}>
+                <Dropdown
+                    label={i18n.t("Sector")}
+                    items={sectorItems}
+                    value={sector?.id}
+                    onChange={notifySectorChange}
+                    hideLabelWhenValueSelected
+                />
+            </span>
+        </ReportTextField>
+    );
+}
+
+const styles = {
+    dropdown: { display: "inline-grid" },
 };
 
-export default React.memo(ReportTextFieldForSector);
+export default reactMemo(ReportTextFieldForSector);

--- a/src/pages/report/TextFieldOnBlur.tsx
+++ b/src/pages/report/TextFieldOnBlur.tsx
@@ -4,16 +4,38 @@ import TextField, { TextFieldProps } from "@material-ui/core/TextField";
 type TextFieldOnBlurProps = TextFieldProps & {
     value: string;
     onBlurChange: (s: string) => void;
+    maxContentRows?: number;
 };
 
+type OnBlur = NonNullable<TextFieldProps["onBlur"]>;
+
 const TextFieldOnBlur: React.FC<TextFieldOnBlurProps> = props => {
-    const { onBlurChange, value, ...otherProps } = props;
+    const { onBlurChange, value, maxContentRows, ...otherProps } = props;
+    const [stateValue, setStateValue] = React.useState(value);
+
+    React.useEffect(() => {
+        setStateValue(value);
+    }, [value]);
+
+    const notifyChange = React.useCallback<OnBlur>(() => {
+        onBlurChange(stateValue.trim());
+    }, [onBlurChange, stateValue]);
+
+    const setStateValueFromEvent = React.useCallback<OnBlur>(
+        ev => {
+            const value = ev.target.value;
+            const canChangeValue = !maxContentRows || value.split(/\n/).length <= maxContentRows;
+            if (canChangeValue) setStateValue(ev.target.value);
+        },
+        [setStateValue, maxContentRows]
+    );
 
     return (
         <TextField
             {...otherProps}
-            defaultValue={value}
-            onBlur={ev => onBlurChange(ev.target.value.trim())}
+            value={stateValue || ""}
+            onChange={setStateValueFromEvent}
+            onBlur={notifyChange}
         />
     );
 };

--- a/src/utils/react.tsx
+++ b/src/utils/react.tsx
@@ -8,3 +8,5 @@ export function renderJoin(nodes: ReactNode[], separator: ReactNode): ReactNode 
         .map((node, idx) => <React.Fragment key={idx}>{node || "-"}</React.Fragment>)
         .value();
 }
+
+export const reactMemo: <T>(_component: T) => T = React.memo;


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/cay3mw

### :memo: Implementation

- Add key executiveSummariesSelected to store, so we still persist all summaries, but only show the selected ones.
- No migration is required.
- Even if no more than 3 sectors are relevant for the report, the selectors appear. This way, the user can decide both the order and visibility.

### :fire: Notes for the reviewer

Existing MERs will have all selectors unchecked. As we already checked, PRO has only one report with data, so that's not really a problem.

### :art: Screenshots

![image](https://user-images.githubusercontent.com/24643/104916131-f033f900-5991-11eb-8c61-8e635f190d28.png)
