### PR TITLE
Keep previous created date field for all objects on a metadata post [cd12tk]

### DIFF
--- a/src/models/Project.ts
+++ b/src/models/Project.ts
@@ -80,6 +80,7 @@ export type Location = Omit<LocationC, "countries">;
 
 export interface ProjectData {
     id: Id;
+    created: Moment | undefined;
     name: string;
     description: string;
     awardNumber: string;
@@ -137,6 +138,7 @@ export const monthFormat = "YYYYMM";
 
 const defaultProjectData = {
     id: undefined,
+    created: undefined,
     name: "",
     description: "",
     awardNumber: "",
@@ -196,6 +198,7 @@ class Project {
 
     static fieldNames: Record<ProjectField, string> = {
         id: i18n.t("Id"),
+        created: i18n.t("Created"),
         name: i18n.t("Name"),
         dataElementsSelection: i18n.t("Data Elements Selection"),
         dataElementsMER: i18n.t("Data Elements MER"),

--- a/src/models/__tests__/Project.spec.ts
+++ b/src/models/__tests__/Project.spec.ts
@@ -59,6 +59,7 @@ describe("Project", () => {
 
         it("has empty values", () => {
             expect(project.name).toEqual("");
+            expect(project.created).toEqual(undefined);
             expect(project.description).toEqual("");
             expect(project.awardNumber).toEqual("");
             expect(project.subsequentLettering).toEqual("");
@@ -585,7 +586,7 @@ async function getProject(): Promise<Project> {
     mock.onGet("/metadata", {
         params: {
             "organisationUnits:fields":
-                "attributeValues[attribute[id],value],closedDate,code,description,displayName,id,name,openingDate,organisationUnitGroups[attributeValues[attribute[id],value],groupSets[id],id,name],parent[attributeValues[attribute[id],value],displayName,id,name,path],path",
+                "attributeValues[attribute[id],value],closedDate,code,created,description,displayName,id,name,openingDate,organisationUnitGroups[attributeValues[attribute[id],value],groupSets[id],id,name],parent[attributeValues[attribute[id],value],displayName,id,name,path],path",
             "organisationUnits:filter": ["id:eq:R3rGhxWbAI9"],
             "dataSets:fields":
                 "code,dataInputPeriods[closingDate,openingDate,period],dataSetElements[categoryCombo[id],dataElement[id]],expiryDays,externalAccess,id,openFuturePeriods,publicAccess,sections[code,dataElements[id]],userAccesses[access,displayName,id],userGroupAccesses[access,displayName,id]",

--- a/src/models/__tests__/ProjectDb.spec.ts
+++ b/src/models/__tests__/ProjectDb.spec.ts
@@ -120,6 +120,10 @@ describe("ProjectDb", () => {
                 },
             }).replyOnce(200, orgUnitsMetadata);
 
+            mock.onGet(
+                "/metadata?filter=id:in:[WGC0DJ0YSis,eu2XF73JOzl,GG0k0oNhgS7,em8NIwi0KvM,OKEZCrPzqph,WIEp6vpQw6n,OUGGW1cHaYy,SCS4Dusnfdd,CwUxT9UIX3z,WgOMVlwSV2i,qyG6foGIKEx,OiCmorbkHNf,i07AWJAND8a,iqqgnCj9DQj,GycLEG8dPPO,iOk52Z42bjp,SQSYgZjfA3z,aeGIpbJkZAX,GM6SxObVwI3,GEe8ZzUkVwG,KOiGcdA4JjD,CS7csnUtibF,uqMTlezGj0I,OS2K2s8VIIq,ayOoqqk9Rnb,ew6e1j5HwkE,mUCwcWSsa9T,KeWVSa2rbYm,i6CWRJp61Hp,eYaYrZfbJT1,uG9C9z46CNK,qmsj4FqnVPX,uiyYMLiDaK2,u6Sin4Fy1Wt,ukewRkZsyCI,GqYJDh6asM8,me6p7L8VHXl,CYYNLjxd96q,Gi2PegQJhbu,Ww2X5s48uQx,CMqisHj7sP9,WGWGaYtwJzp]"
+            ).replyOnce(200, {});
+
             mock.onPost("/metadata", expectedMetadataPost).replyOnce(200, metadataResponse);
 
             mock.onPost("/metadata", expectedSectionsMetadataPost).replyOnce(200, metadataResponse);


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/cd12tk

### :memo: Implementation

Problem: On POST /metadata, objects not containing the field "created", will have it set to the current time. We need to explicitly post the old value.

Workaround: request all the objects before POSTing them and merge the previous value of "created". This way we keep not only the orgUnit, but all the metadata objects related to the problem.

### :art: Screenshots

![image](https://user-images.githubusercontent.com/24643/105153138-5c386d80-5b08-11eb-90e8-d791eb54e8b9.png)
