### PR TITLE
Fix livelihoods sector code [migration]

### DIFF
--- a/src/migrations/tasks/04.set-livelihoods-code.ts
+++ b/src/migrations/tasks/04.set-livelihoods-code.ts
@@ -1,0 +1,52 @@
+import { D2Api } from "../../types/d2-api";
+import { Debug, Migration } from "../types";
+import { post } from "./common";
+
+class FixLivelihoodsCode {
+    constructor(private api: D2Api, private debug: Debug) {}
+
+    async execute() {
+        await this.createUserRole();
+    }
+
+    async createUserRole() {
+        const { sections: sections, options } = await this.api.metadata
+            .get({
+                sections: {
+                    fields: { $owner: true },
+                    filter: { code: { $ilike: "SECTOR\\_LIVELIHOOD\\_" } },
+                },
+                options: {
+                    fields: { $owner: true },
+                    filter: { code: { eq: "SECTOR_LIVELIHOOD" } },
+                },
+            })
+            .getData();
+
+        const newSections = sections.map(section => ({
+            ...section,
+            code: section.code.replace("SECTOR_LIVELIHOOD_", "SECTOR_LIVELIHOODS_"),
+        }));
+
+        const newOptions = options.map(option => ({
+            ...option,
+            code: "SECTOR_LIVELIHOODS",
+        }));
+
+        console.debug({ sections: newSections.length, options: newOptions.length });
+
+        const res = await post(this.api, this.debug, {
+            sections: newSections,
+            options: newOptions,
+        });
+
+        console.debug(res);
+    }
+}
+
+const migration: Migration = {
+    name: "Fix Livehoods code",
+    migrate: async (api: D2Api, debug: Debug) => new FixLivelihoodsCode(api, debug).execute(),
+};
+
+export default migration;

--- a/src/migrations/tasks/04.set-livelihoods-code.ts
+++ b/src/migrations/tasks/04.set-livelihoods-code.ts
@@ -10,7 +10,7 @@ class FixLivelihoodsCode {
     }
 
     async createUserRole() {
-        const { sections: sections, options } = await this.api.metadata
+        const { sections, options } = await this.api.metadata
             .get({
                 sections: {
                     fields: { $owner: true },

--- a/src/migrations/tasks/index.ts
+++ b/src/migrations/tasks/index.ts
@@ -5,5 +5,6 @@ export async function getMigrationTasks(): Promise<MigrationTasks> {
         migration(1, (await import("./01.update-dashboards")).default),
         migration(2, (await import("./02.award-number-as-org-unit-group")).default),
         migration(3, (await import("./03.add-role-mer-approver")).default),
+        migration(4, (await import("./04.set-livelihoods-code")).default),
     ];
 }


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/gd13np

We had a mix of SECTOR_LIVELIHOOD and SECTOR_LIVELIHOOD**S**

### :memo: Implementation

- Rename dataSet->sections and optionSet->options code for livelihood, always plural -> SECTOR_LIVELIHOODS.