### PR TITLE
Extend covid disaggregation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ cypress/videos/
 # Custom
 /scripts/
 data-management-app.zip
+src/scripts/data
 bak/
 src/dev
 .eslintcache

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-05-05T10:13:55.444Z\n"
-"PO-Revision-Date: 2021-05-05T10:13:55.444Z\n"
+"POT-Creation-Date: 2021-05-24T09:51:57.168Z\n"
+"PO-Revision-Date: 2021-05-24T09:51:57.168Z\n"
 
 msgid "Name"
 msgstr ""
@@ -568,6 +568,9 @@ msgid "created"
 msgstr ""
 
 msgid "updated"
+msgstr ""
+
+msgid "Project '{{projectName}}' [dangling data values]"
 msgstr ""
 
 msgid "Award Number {{awardNumber}}"

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
         "cy:e2e:open": "yarn cypress-run-migrations && CYPRESS_E2E=true cypress open -b chrome",
         "cy:e2e:run": "yarn cypress-run-migrations && CYPRESS_E2E=true cypress run -b chrome --headless",
         "ts-node": "ts-node -P tsconfig-cli.json",
-        "cypress-run-migrations": "yarn ts-node src/migrations/cli.ts $CYPRESS_EXTERNAL_API $CYPRESS_DHIS2_AUTH",
+        "run-migrations": "yarn ts-node src/migrations/cli.ts",
+        "cypress-run-migrations": "yarn run-migrations $CYPRESS_EXTERNAL_API $CYPRESS_DHIS2_AUTH",
         "check-uncommited": "! git status -uno --porcelain | grep '.'",
         "generate-test-fixtures": "yarn run ts src/models/Config.ts"
     },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "@dhis2/d2-ui-forms": "^6.5.3",
         "@dhis2/ui-core": "^4.8.0",
         "@dhis2/ui-widgets": "^2.0.8",
-        "@eyeseetea/d2-api": "1.8.3",
+        "@eyeseetea/d2-api": "1.8.5-beta.1",
         "@eyeseetea/d2-ui-components": "2.6.6",
         "@material-ui/core": "4.11.3",
         "@material-ui/icons": "4.11.2",

--- a/src/components/objects-list/ObjectsList.tsx
+++ b/src/components/objects-list/ObjectsList.tsx
@@ -76,7 +76,7 @@ export function ObjectsList<T extends ReferenceObject>(
 
                             {children}
 
-                            <Spinner isVisible={isLoading} />
+                            <Spinner isLoading={isLoading} />
                         </React.Fragment>
                     }
                 />

--- a/src/components/spinner/Spinner.jsx
+++ b/src/components/spinner/Spinner.jsx
@@ -14,7 +14,7 @@ class Spinner extends React.Component {
 }
 
 const style = {
-    marginLeft: "48%",
+    marginLeft: 10,
 };
 
 export default React.memo(Spinner);

--- a/src/migrations/tasks/05.extend-covid-disaggregation.ts
+++ b/src/migrations/tasks/05.extend-covid-disaggregation.ts
@@ -1,0 +1,67 @@
+import { D2Api } from "../../types/d2-api";
+import { getUid } from "../../utils/dhis2";
+import { Debug, Migration } from "../types";
+import { error, post } from "./common";
+
+class ExtendCovidDisaggregation {
+    constructor(private api: D2Api, private debug: Debug) {}
+
+    async execute() {
+        await this.updateCategoryOptions();
+    }
+
+    async updateCategoryOptions() {
+        const { categories, categoryOptions } = await this.api.metadata
+            .get({
+                categories: {
+                    fields: { $owner: true },
+                    filter: { code: { eq: "COVID19" } },
+                },
+                categoryOptions: {
+                    fields: { $owner: true },
+                    filter: { code: { eq: "COVID19" } },
+                },
+            })
+            .getData();
+
+        const categoryCovid = categories[0];
+        if (!categoryCovid) error("COVID category not found");
+
+        const categoryOptionCovid = categoryOptions[0];
+        if (!categoryOptionCovid) error("COVID category option not found");
+
+        const categoryOptionNonCovid = {
+            id: getUid("categoryOptions", "covid-no"),
+            name: "Non-COVID-19",
+            code: "COVID19_NO",
+        };
+
+        this.debug(`Covid category: ${categoryCovid.id}`);
+        this.debug(`Covid category option: ${categoryOptionCovid.id}`);
+
+        const categoryCovidUpdated = {
+            ...categoryCovid,
+            categoryOptions: [{ id: categoryOptionCovid.id }, { id: categoryOptionNonCovid.id }],
+        };
+
+        this.debug(`Add category option: ${categoryOptionNonCovid.name}`);
+
+        const res = await post(this.api, this.debug, {
+            categories: [categoryCovidUpdated],
+            categoryOptions: [categoryOptionNonCovid],
+        });
+
+        console.debug(res);
+
+        this.debug("Update category option combos");
+        await this.api.maintenance.categoryOptionComboUpdate().getData();
+    }
+}
+
+const migration: Migration = {
+    name: "Extend COVID-19 disaggregation",
+    migrate: async (api: D2Api, debug: Debug) =>
+        new ExtendCovidDisaggregation(api, debug).execute(),
+};
+
+export default migration;

--- a/src/migrations/tasks/common.ts
+++ b/src/migrations/tasks/common.ts
@@ -19,6 +19,10 @@ export async function getProjectIds(api: D2Api, config: Config, debug: Debug): P
         .value();
 }
 
+export function error(msg: string) {
+    throw Error(msg);
+}
+
 export async function post<Payload>(api: D2Api, debug: Debug, payload: Payload) {
     const res = await api.metadata.post(payload).getData();
     if (res.status !== "OK") {

--- a/src/migrations/tasks/index.ts
+++ b/src/migrations/tasks/index.ts
@@ -6,5 +6,6 @@ export async function getMigrationTasks(): Promise<MigrationTasks> {
         migration(2, (await import("./02.award-number-as-org-unit-group")).default),
         migration(3, (await import("./03.add-role-mer-approver")).default),
         migration(4, (await import("./04.set-livelihoods-code")).default),
+        migration(5, (await import("./05.extend-covid-disaggregation")).default),
     ];
 }

--- a/src/models/ProjectDb.ts
+++ b/src/models/ProjectDb.ts
@@ -578,7 +578,8 @@ export default class ProjectDb {
 
         const validPairIds = new Set(
             _.flatMap(dataElements, de => {
-                const cocIds = cocIdsByCategoryComboId[de.categoryCombo.id] || [];
+                const categoryCombo = project.disaggregation.getCategoryCombo(de.id);
+                const cocIds = cocIdsByCategoryComboId[categoryCombo.id] || [];
                 return cocIds.map(cocId => [de.id, cocId].join("-"));
             })
         );

--- a/src/models/ProjectDb.ts
+++ b/src/models/ProjectDb.ts
@@ -14,7 +14,7 @@ import Project, {
 import { getMonthsRange, toISOString } from "../utils/date";
 import "../utils/lodash-mixins";
 import ProjectDashboard from "./ProjectDashboard";
-import { getUid, getDataStore, getIds, getRefs, flattenPayloads } from "../utils/dhis2";
+import { getUid, getDataStore, getIds, getRefs, flattenPayloads, getId } from "../utils/dhis2";
 import { Config } from "./Config";
 import { runPromises } from "../utils/promises";
 import DataElementsSet from "./dataElementsSet";
@@ -553,6 +553,96 @@ export default class ProjectDb {
         const project = new Project(api, config, { ...projectData, initialData: projectData });
         return project;
     }
+
+    async getDanglingDataValues(): Promise<DataValue[]> {
+        const { api, project } = this;
+        const dataElements = project.getSelectedDataElements();
+        const dataSetIds = _.compact([project.dataSets?.actual.id, project.dataSets?.target.id]);
+
+        if (!project.orgUnit || _.isEmpty(dataSetIds)) return [];
+
+        const { dataValues } = await api.dataValues
+            .getSet({
+                orgUnit: [project.orgUnit.id],
+                dataSet: dataSetIds,
+                startDate: "1970",
+                endDate: (new Date().getFullYear() + 1).toString(),
+            })
+            .getData();
+
+        const cocIdsByCategoryComboId = _(this.config.categoryCombos)
+            .values()
+            .map(catCombo => [catCombo.id, getIds(catCombo.categoryOptionCombos)] as [Id, Id[]])
+            .fromPairs()
+            .value();
+
+        const validPairIds = new Set(
+            _.flatMap(dataElements, de => {
+                const cocIds = cocIdsByCategoryComboId[de.categoryCombo.id] || [];
+                return cocIds.map(cocId => [de.id, cocId].join("-"));
+            })
+        );
+
+        const danglingDataValues = dataValues
+            .filter(dataValue => dataValue.value && dataValue.value !== "0")
+            .filter(dv => !validPairIds.has([dv.dataElement, dv.categoryOptionCombo].join("-")));
+
+        const cocIdsFromDataValues = _(danglingDataValues)
+            .flatMap(dv => [dv.categoryOptionCombo, dv.attributeOptionCombo])
+            .uniq()
+            .value();
+
+        const { categoryOptionCombos } = await api.metadata
+            .get({
+                categoryOptionCombos: {
+                    fields: { id: true, name: true },
+                    filter: { id: { in: cocIdsFromDataValues } },
+                },
+            })
+            .getData();
+
+        const dataElementsById = _.keyBy(dataElements, getId);
+        const cocsById = _.keyBy(categoryOptionCombos, getId);
+
+        const dataValuesInfo = danglingDataValues.map((dv): DataValue | null => {
+            const dataElement = _(dataElementsById).get(dv.dataElement, null);
+            const categoryOptionCombo = _(cocsById).get(dv.categoryOptionCombo, null);
+            const attributeOptionCombo = _(cocsById).get(dv.attributeOptionCombo, null);
+
+            if (!dataElement || !categoryOptionCombo || !attributeOptionCombo) {
+                console.warn("Metadata not found for datavalue", dv);
+                return null;
+            } else {
+                return {
+                    dataElement,
+                    categoryOptionCombo,
+                    attributeOptionCombo,
+                    period: dv.period,
+                    value: dv.value,
+                };
+            }
+        });
+
+        return _.compact(dataValuesInfo);
+    }
+}
+
+export interface DataValue {
+    dataElement: { id: Id; name: string; code: string };
+    categoryOptionCombo: { id: Id; name: string };
+    attributeOptionCombo: { id: Id; name: string };
+    period: string;
+    value: string;
+}
+
+export function getStringDataValue(dataValue: DataValue): string {
+    return [
+        `[${dataValue.dataElement.code}] ${dataValue.dataElement.name}`,
+        dataValue.attributeOptionCombo.name,
+        dataValue.categoryOptionCombo.name,
+        dataValue.period,
+        `value=${dataValue.value}`,
+    ].join(" - ");
 }
 
 async function getDataElementIdsForMer(api: D2Api, id: string) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1473,10 +1473,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@eyeseetea/d2-api@1.8.3":
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/@eyeseetea/d2-api/-/d2-api-1.8.3.tgz#7b5e9ccb5e9c6fbee3ec393798b3f91e80d36e2b"
-  integrity sha512-+OWu2KGBR4Zq7PozyuvtWtgdaQQ6jLT16bNz9Gf+kRyXXJ9o7rV54/mx6XWocDu/m0Zuh8St5aPsxq2ZXUHIHQ==
+"@eyeseetea/d2-api@1.8.5-beta.1":
+  version "1.8.5-beta.1"
+  resolved "https://registry.npmjs.org/@eyeseetea/d2-api/-/d2-api-1.8.5-beta.1.tgz#7b891eed596a5d8f48f799fdf799e956f8d45a1e"
+  integrity sha512-6v/uA9sPOPv4NPwRCIgWT+Wb6Y5OQd8u8nnLb36atSyBGgJdKbNdjEFj9FGOmu/i1YMqGCEWQ1FBFgNqLRc4Hw==
   dependencies:
     "@babel/runtime" "^7.5.4"
     "@dhis2/d2-i18n" "^1.0.5"


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/j32x9v
* d2-api beta: https://github.com/EyeSeeTea/d2-api/pull/99

### :memo: Implementation

- New migration-5 creates a category option "Non-COVID" inside category "COVID" and runs `categoryOptionComboUpdate` maintenance action.
- Added maintenance endpoints to `d2-api`:  https://github.com/EyeSeeTea/d2-api/pull/99
- Notify dangling data values by email (recipient: app-config -> `notifyEmailOnProjectSave`): gets all data values for a project org unit, and identifies those with a category option combo non-matching its current disaggregation in the project. Note: only current data elements in the project are considered. Do we want all of them?

### :test_tube: Notes for the tester

- Docker (created from PRO): `d2-docker start eyeseetea/dhis2-data:2.32.6-samaritans`
- If you don't see changes the non-COVID options appear in the data entry forms even though the migration is applied, clear the cache (Chrome: devtools -> Application -> Storage -> Clear site data) and reload.

### :art: Screenshots

![image](https://user-images.githubusercontent.com/24643/119335255-6f14a780-bc8c-11eb-9518-21c69099d8e1.png)