### PR TITLE
Add project export/import (metadata/data) to be used in cloning tasks

### DIFF
--- a/src/models/MerReport.ts
+++ b/src/models/MerReport.ts
@@ -557,8 +557,8 @@ export function getProjectStorageKey(organisationUnit: Ref): string {
     return ["project", organisationUnit.id].join("-");
 }
 
-function getReportStorageKey(organisationUnit: Ref): string {
-    return ["mer", organisationUnit.id].join("-");
+export function getReportStorageKey(country: Ref): string {
+    return ["mer", country.id].join("-");
 }
 
 async function getAnalytics(

--- a/src/scripts/common.ts
+++ b/src/scripts/common.ts
@@ -28,9 +28,19 @@ export function readDataFilePath<T>(filename: string): T {
 export function writeDataFilePath(filename: string, obj: object): void {
     const filePath = getDataFilePath(filename);
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    writeJson(filePath, obj);
+}
+
+export function writeJson(jsonPath: string, obj: object): void {
     const json = JSON.stringify(obj, null, 4);
-    fs.writeFileSync(filePath, json);
-    console.error(`Written: ${filePath}`);
+    fs.writeFileSync(jsonPath, json);
+    console.error(`Written: ${jsonPath}`);
+}
+
+export function readJson<T>(jsonPath: string): T {
+    console.error(`Read: ${jsonPath}`);
+    const json = fs.readFileSync(jsonPath, "utf8");
+    return JSON.parse(json);
 }
 
 export function assert<T>(obj: T | null | undefined | false, msg?: string): asserts obj {

--- a/src/scripts/projects.ts
+++ b/src/scripts/projects.ts
@@ -1,0 +1,103 @@
+import _ from "lodash";
+import parse from "parse-typed-args";
+import { promiseMap } from "../migrations/utils";
+import { Config } from "../models/Config";
+import ProjectDb, { ProjectJson } from "../models/ProjectDb";
+import { D2Api } from "../types/d2-api";
+import { getApp, readJson, writeJson } from "./common";
+
+async function main() {
+    const parser = parse({
+        opts: { url: {}, from: {} },
+    });
+    const { opts, args } = parser(process.argv);
+
+    const usage = `projects
+            --url=DHIS2_URL
+            [--from=CREATED_FROM_TIMESTAMP]
+            import projects.json OR export projects.json
+        `;
+    const app = opts.url ? await getApp({ baseUrl: opts.url }) : null;
+    const command = args[0];
+
+    if (!app || !command) {
+        console.error(usage);
+    } else if (command === "export" && args[1]) {
+        const jsonPath = args[1];
+        exportProjects(app, { jsonPath, from: opts.from });
+    } else if (command === "import" && args[1]) {
+        const jsonPath = args[1];
+        importProjects(app, { jsonPath });
+    } else {
+        console.error(`Unknown command: ${command}`);
+        console.error(usage);
+    }
+}
+
+async function exportProjects(
+    app: { api: D2Api; config: Config },
+    options: { jsonPath: string; from?: string }
+) {
+    const { api, config } = app;
+    const { jsonPath, from } = options;
+
+    const orgUnits$ = api.metadata.get({
+        organisationUnits: {
+            fields: {
+                id: true,
+                name: true,
+                attributeValues: { attribute: { id: true }, value: true },
+            },
+            filter: from ? { created: { ge: from } } : {},
+        },
+    });
+
+    const orgUnits = _(await orgUnits$.getData())
+        .thru(res => res.organisationUnits)
+        .filter(orgUnit =>
+            _.some(
+                orgUnit.attributeValues,
+                av => av.attribute.id === config.attributes.createdByApp.id && av.value === "true"
+            )
+        )
+        .value();
+
+    console.debug(`OrgUnits: ${orgUnits.length}`);
+
+    const jsonCollection = await promiseMap(orgUnits, async orgUnit => {
+        console.debug(`Get project: ${orgUnit.name} (${orgUnit.id})`);
+        const project = await ProjectDb.get(api, config, orgUnit.id);
+        const projectDb = new ProjectDb(project);
+        const json = await projectDb.toJSON();
+        return json;
+    });
+
+    await writeJson(jsonPath, jsonCollection);
+}
+
+async function importProjects(app: { api: D2Api; config: Config }, options: { jsonPath: string }) {
+    const { api, config } = app;
+    const { jsonPath } = options;
+    const jsonCollection = readJson<ProjectJson[]>(jsonPath);
+
+    const orgUnits$ = api.metadata.get({ organisationUnits: { fields: { id: true } } });
+    const { organisationUnits: existingOrgUnits } = await orgUnits$.getData();
+
+    const allOrgUnitIds = new Set(
+        _(jsonCollection)
+            .flatMap(json => json.metadata.organisationUnits.map(ou => ou.id))
+            .concat(existingOrgUnits.map(ou => ou.id))
+            .compact()
+            .value()
+    );
+
+    for (const json of jsonCollection) {
+        console.debug(`Import: ${json.name} (${json.id})`);
+        await ProjectDb.fromJSON(api, config, json, allOrgUnitIds);
+    }
+}
+
+main().catch(err => {
+    console.error("ERROR", err, err.response);
+    process.exit(1);
+});


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/1yt8jk8
Needs in server: https://github.com/EyeSeeTea/d2-docker/pull/84

### :memo: Implementation

- Added a single filter by startDate.
- Export projects metadata, dataStore(used in MER->selectedDataElementIds), and data values
- On import, we need to remove org units from the references that may not exist in the server anymore.

### :fire: Notes for the reviewer

We will test this feature when cloning PRO->Training. For the record, commands:
```
$ yarn ts-node src/scripts/projects.ts --url='http://admin:PASSWORD@localhost:8080' --from=2022-02-01 export projects.json
yarn ts-node src/scripts/projects.ts --url='http://admin:PASSWORD@localhost:8080'  import projects.json
```