### PR TITLE
Replace nbsp chars by normal space on email body

### DIFF
--- a/src/models/ProjectNotification.ts
+++ b/src/models/ProjectNotification.ts
@@ -123,10 +123,12 @@ The reason provided by the user was:
     }
 }
 
+const nbsp = /\xa0/g;
+
 function html2Text(element: ReactElement): string {
     const html = ReactDOMServer.renderToStaticMarkup(element);
     const text = striptags(html, [], "\n");
-    const textWithoutBlankLines = text.replace(/^\s*$(?:\r\n?|\n)/gm, "");
+    const textWithoutBlankLines = text.replace(/^\s*$(?:\r\n?|\n)/gm, "").replace(nbsp, " ");
     return textWithoutBlankLines;
 }
 


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://app.clickup.com/t/2mjjnwy

### :memo: Implementation

- Replace char 160 / xA0 / nbsp with a normal space.